### PR TITLE
fix: coalesce empty string for FormalFrameworkName

### DIFF
--- a/src/OrganisationRegistry.SqlServer/Organisation/OrganisationFormalFrameworkListItemView.cs
+++ b/src/OrganisationRegistry.SqlServer/Organisation/OrganisationFormalFrameworkListItemView.cs
@@ -146,7 +146,7 @@ namespace OrganisationRegistry.SqlServer.Organisation
                 organisationFormalFramework.OrganisationFormalFrameworkId = message.Body.OrganisationFormalFrameworkId;
                 organisationFormalFramework.OrganisationId = message.Body.OrganisationId;
                 organisationFormalFramework.FormalFrameworkId = message.Body.FormalFrameworkId;
-                organisationFormalFramework.FormalFrameworkName = message.Body.FormalFrameworkName;
+                organisationFormalFramework.FormalFrameworkName = message.Body.FormalFrameworkName ?? string.Empty;
                 organisationFormalFramework.ParentOrganisationId = message.Body.ParentOrganisationId;
                 organisationFormalFramework.ParentOrganisationName = message.Body.ParentOrganisationName;
                 organisationFormalFramework.ValidFrom = message.Body.ValidFrom;


### PR DESCRIPTION
Because earlier events did not have FormalFrameworkName in them, replace NULL value with empty string to allow the event to pass. We'll need some compensating events (eg FormalFrameworkUpdated) later to replace these empty strings with the actual names.