### PR TITLE
fix: redirect using $http_host

### DIFF
--- a/src/OrganisationRegistry.UI/default.conf
+++ b/src/OrganisationRegistry.UI/default.conf
@@ -7,7 +7,7 @@ server {
 
     # Redirect /oic
     location ~ /oic* {
-      rewrite ^ /#/$uri redirect;
+      rewrite ^ $scheme://$http_host/#$uri redirect;
       break;
     }
 


### PR DESCRIPTION
Redirect using the $http_host variable, which contains the hostname and
port from the original request.