### PR TITLE
feat: don't use memory caches for ES

### DIFF
--- a/src/OrganisationRegistry.ElasticSearch.Projections/Body/BodyRunner.cs
+++ b/src/OrganisationRegistry.ElasticSearch.Projections/Body/BodyRunner.cs
@@ -16,7 +16,6 @@ namespace OrganisationRegistry.ElasticSearch.Projections.Body
 
         private new static readonly Type[] EventHandlers =
         {
-            typeof(MemoryCachesMaintainer),
             typeof(BodyHandler)
         };
 

--- a/src/OrganisationRegistry.ElasticSearch.Projections/Cache/BodyCache.cs
+++ b/src/OrganisationRegistry.ElasticSearch.Projections/Cache/BodyCache.cs
@@ -1,0 +1,84 @@
+﻿namespace OrganisationRegistry.ElasticSearch.Projections.Cache
+{
+    using System.Data.Common;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Infrastructure;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging;
+    using Organisation.Events;
+    using OrganisationRegistry.Body.Events;
+    using OrganisationRegistry.Infrastructure.Events;
+    using SqlServer;
+    using SqlServer.ElasticSearchProjections;
+
+    public class BodyCache :
+        BaseProjection<BodyCache>,
+        IEventHandler<BodyRegistered>,
+        IEventHandler<BodyInfoChanged>,
+        IEventHandler<InitialiseProjection>
+    {
+        private readonly IContextFactory _contextFactory;
+
+        public BodyCache(
+            ILogger<BodyCache> logger,
+            IContextFactory contextFactory) : base(logger)
+        {
+            _contextFactory = contextFactory;
+        }
+
+        public async Task Handle(DbConnection dbConnection, DbTransaction dbTransaction,
+            IEnvelope<BodyRegistered> message)
+        {
+            var organisation = new BodyCacheItem
+            {
+                Id = message.Body.BodyId,
+                Name = message.Body.Name,
+            };
+
+            await using var context = _contextFactory.Create();
+            await context.BodyCache.AddAsync(organisation);
+            await context.SaveChangesAsync();
+        }
+
+        public async Task Handle(DbConnection dbConnection, DbTransaction dbTransaction,
+            IEnvelope<BodyInfoChanged> message)
+        {
+            await using var context = _contextFactory.Create();
+            var organisation = await context
+                .BodyCache
+                .SingleAsync(x => x.Id == message.Body.BodyId);
+
+            organisation.Name = message.Body.Name;
+
+            await context.SaveChangesAsync();
+        }
+
+        public async Task Handle(DbConnection dbConnection, DbTransaction dbTransaction,
+            IEnvelope<InitialiseProjection> message)
+        {
+            if (message.Body.ProjectionName != CacheRunner.ProjectionName)
+                return;
+
+            Logger.LogInformation("Rebuilding index for {ProjectionName}.", message.Body.ProjectionName);
+            Logger.LogInformation("Initialization {ProjectionTableNames} for {ProjectionName} started.",
+                BodyCacheForEsConfiguration.TableName, message.Body.ProjectionName);
+
+            await using (var context = _contextFactory.Create())
+                while (await DeleteRows(context) > 0)
+                {
+                }
+
+            Logger.LogInformation("Initialization {ProjectionTableNames} for {ProjectionName} finished.",
+                BodyCacheForEsConfiguration.TableName, message.Body.ProjectionName);
+        }
+
+        private static async Task<int> DeleteRows(DbContext context)
+        {
+            return await context.Database.ExecuteSqlRawAsync(
+                string.Concat(new[] {BodyCacheForEsConfiguration.TableName}.Select(tableName =>
+                    $"DELETE TOP(500) FROM [ElasticSearchProjections].[{tableName}];")));
+        }
+
+    }
+}

--- a/src/OrganisationRegistry.ElasticSearch.Projections/Cache/BodySeatCache.cs
+++ b/src/OrganisationRegistry.ElasticSearch.Projections/Cache/BodySeatCache.cs
@@ -1,0 +1,87 @@
+﻿namespace OrganisationRegistry.ElasticSearch.Projections.Cache
+{
+    using System.Data.Common;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Infrastructure;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging;
+    using Organisation.Events;
+    using OrganisationRegistry.Body.Events;
+    using OrganisationRegistry.Infrastructure.Events;
+    using SqlServer;
+    using SqlServer.ElasticSearchProjections;
+
+    public class BodySeatCache :
+        BaseProjection<BodySeatCache>,
+        IEventHandler<BodySeatAdded>,
+        IEventHandler<BodySeatUpdated>,
+        IEventHandler<InitialiseProjection>
+    {
+        private readonly IContextFactory _contextFactory;
+
+        public BodySeatCache(
+            ILogger<BodySeatCache> logger,
+            IContextFactory contextFactory) : base(logger)
+        {
+            _contextFactory = contextFactory;
+        }
+
+        public async Task Handle(DbConnection dbConnection, DbTransaction dbTransaction,
+            IEnvelope<BodySeatAdded> message)
+        {
+            var organisation = new BodySeatCacheItem
+            {
+                Id = message.Body.BodySeatId,
+                Name = message.Body.Name,
+                Number = message.Body.BodySeatNumber,
+                IsPaid = message.Body.PaidSeat
+            };
+
+            await using var context = _contextFactory.Create();
+            await context.BodySeatCache.AddAsync(organisation);
+            await context.SaveChangesAsync();
+        }
+
+        public async Task Handle(DbConnection dbConnection, DbTransaction dbTransaction,
+            IEnvelope<BodySeatUpdated> message)
+        {
+            await using var context = _contextFactory.Create();
+            var organisation = await context
+                .BodySeatCache
+                .SingleAsync(x => x.Id == message.Body.BodySeatId);
+
+            organisation.Name = message.Body.Name;
+            organisation.IsPaid = message.Body.PaidSeat;
+
+            await context.SaveChangesAsync();
+        }
+
+        public async Task Handle(DbConnection dbConnection, DbTransaction dbTransaction,
+            IEnvelope<InitialiseProjection> message)
+        {
+            if (message.Body.ProjectionName != CacheRunner.ProjectionName)
+                return;
+
+            Logger.LogInformation("Rebuilding index for {ProjectionName}.", message.Body.ProjectionName);
+            Logger.LogInformation("Initialization {ProjectionTableNames} for {ProjectionName} started.",
+                BodySeatCacheForEsConfiguration.TableName, message.Body.ProjectionName);
+
+            await using (var context = _contextFactory.Create())
+                while (await DeleteRows(context) > 0)
+                {
+                }
+
+            Logger.LogInformation("Initialization {ProjectionTableNames} for {ProjectionName} finished.",
+                BodySeatCacheForEsConfiguration.TableName, message.Body.ProjectionName);
+        }
+
+        private static async Task<int> DeleteRows(DbContext context)
+        {
+            return await context.Database.ExecuteSqlRawAsync(
+                string.Concat(new[] {BodySeatCacheForEsConfiguration.TableName}.Select(tableName =>
+                    $"DELETE TOP(500) FROM [ElasticSearchProjections].[{tableName}];")));
+        }
+
+    }
+}

--- a/src/OrganisationRegistry.ElasticSearch.Projections/Cache/OrganisationCache.cs
+++ b/src/OrganisationRegistry.ElasticSearch.Projections/Cache/OrganisationCache.cs
@@ -1,0 +1,128 @@
+﻿namespace OrganisationRegistry.ElasticSearch.Projections.Cache
+{
+    using System.Data.Common;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Infrastructure;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging;
+    using Organisation.Events;
+    using OrganisationRegistry.Infrastructure.Events;
+    using SqlServer;
+    using SqlServer.ElasticSearchProjections;
+
+    public class OrganisationCache :
+        BaseProjection<OrganisationCache>,
+        IEventHandler<OrganisationCreated>,
+        IEventHandler<OrganisationCreatedFromKbo>,
+        IEventHandler<OrganisationInfoUpdated>,
+        IEventHandler<OrganisationInfoUpdatedFromKbo>,
+        IEventHandler<OrganisationCouplingWithKboCancelled>,
+        IEventHandler<InitialiseProjection>
+    {
+        private readonly IContextFactory _contextFactory;
+
+        public OrganisationCache(
+            ILogger<OrganisationCache> logger,
+            IContextFactory contextFactory) : base(logger)
+        {
+            _contextFactory = contextFactory;
+        }
+
+        public async Task Handle(DbConnection dbConnection, DbTransaction dbTransaction,
+            IEnvelope<OrganisationCreated> message)
+        {
+            var organisation = new OrganisationCacheItem
+            {
+                Id = message.Body.OrganisationId,
+                Name = message.Body.Name,
+                OvoNumber = message.Body.OvoNumber
+            };
+
+            await using var context = _contextFactory.Create();
+            await context.OrganisationCache.AddAsync(organisation);
+            await context.SaveChangesAsync();
+        }
+
+        public async Task Handle(DbConnection dbConnection, DbTransaction dbTransaction,
+            IEnvelope<OrganisationCreatedFromKbo> message)
+        {
+            var organisation = new OrganisationCacheItem
+            {
+                Id = message.Body.OrganisationId,
+                Name = message.Body.Name,
+                OvoNumber = message.Body.OvoNumber
+            };
+
+            await using var context = _contextFactory.Create();
+            await context.OrganisationCache.AddAsync(organisation);
+            await context.SaveChangesAsync();
+        }
+
+        public async Task Handle(DbConnection dbConnection, DbTransaction dbTransaction,
+            IEnvelope<OrganisationInfoUpdated> message)
+        {
+            await using var context = _contextFactory.Create();
+            var organisation = await context
+                .OrganisationCache
+                .SingleAsync(x => x.Id == message.Body.OrganisationId);
+
+            organisation.Name = message.Body.Name;
+
+            await context.SaveChangesAsync();
+        }
+
+        public async Task Handle(DbConnection dbConnection, DbTransaction dbTransaction,
+            IEnvelope<OrganisationInfoUpdatedFromKbo> message)
+        {
+            await using var context = _contextFactory.Create();
+            var organisation = await context
+                .OrganisationCache
+                .SingleAsync(x => x.Id == message.Body.OrganisationId);
+
+            organisation.Name = message.Body.Name;
+
+            await context.SaveChangesAsync();
+        }
+
+        public async Task Handle(DbConnection dbConnection, DbTransaction dbTransaction,
+            IEnvelope<OrganisationCouplingWithKboCancelled> message)
+        {
+            await using var context = _contextFactory.Create();
+            var organisation = await context
+                .OrganisationCache
+                .SingleAsync(x => x.Id == message.Body.OrganisationId);
+
+            organisation.Name = message.Body.NameBeforeKboCoupling;
+
+            await context.SaveChangesAsync();
+        }
+
+        public async Task Handle(DbConnection dbConnection, DbTransaction dbTransaction,
+            IEnvelope<InitialiseProjection> message)
+        {
+            if (message.Body.ProjectionName != CacheRunner.ProjectionName)
+                return;
+
+            Logger.LogInformation("Rebuilding index for {ProjectionName}.", message.Body.ProjectionName);
+            Logger.LogInformation("Initialization {ProjectionTableNames} for {ProjectionName} started.",
+                OrganisationCacheForEsConfiguration.TableName, message.Body.ProjectionName);
+
+            await using (var context = _contextFactory.Create())
+                while (await DeleteRows(context) > 0)
+                {
+                }
+
+            Logger.LogInformation("Initialization {ProjectionTableNames} for {ProjectionName} finished.",
+                OrganisationCacheForEsConfiguration.TableName, message.Body.ProjectionName);
+        }
+
+        private static async Task<int> DeleteRows(DbContext context)
+        {
+            return await context.Database.ExecuteSqlRawAsync(
+                string.Concat(new[] {OrganisationCacheForEsConfiguration.TableName}.Select(tableName =>
+                    $"DELETE TOP(500) FROM [ElasticSearchProjections].[{tableName}];")));
+        }
+
+    }
+}

--- a/src/OrganisationRegistry.ElasticSearch.Projections/ElasticSearchProjectionsModule.cs
+++ b/src/OrganisationRegistry.ElasticSearch.Projections/ElasticSearchProjectionsModule.cs
@@ -5,6 +5,7 @@ namespace OrganisationRegistry.ElasticSearch.Projections
     using System.Reflection;
     using Autofac.Extensions.DependencyInjection;
     using Body;
+    using Cache;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
@@ -59,6 +60,9 @@ namespace OrganisationRegistry.ElasticSearch.Projections
                 .SingleInstance();
 
             builder.RegisterType<IndividualRebuildRunner>()
+                .SingleInstance();
+
+            builder.RegisterType<CacheRunner>()
                 .SingleInstance();
 
             builder.Populate(_services);

--- a/src/OrganisationRegistry.ElasticSearch.Projections/Organisations/OrganisationsRunner.cs
+++ b/src/OrganisationRegistry.ElasticSearch.Projections/Organisations/OrganisationsRunner.cs
@@ -16,7 +16,6 @@ namespace OrganisationRegistry.ElasticSearch.Projections.Organisations
 
         public new static readonly Type[] EventHandlers =
         {
-            typeof(MemoryCachesMaintainer),
             typeof(Organisation),
             typeof(OrganisationBody),
             typeof(OrganisationBuilding),

--- a/src/OrganisationRegistry.ElasticSearch.Projections/People/Handlers/Person.cs
+++ b/src/OrganisationRegistry.ElasticSearch.Projections/People/Handlers/Person.cs
@@ -87,7 +87,7 @@ namespace OrganisationRegistry.ElasticSearch.Projections.People.Handlers
 
             using (var context = _contextFactory.Create())
                 context.Database.ExecuteSqlRaw(
-                    string.Concat(ProjectionTableNames.Select(tableName => $"DELETE FROM [OrganisationRegistry].[{tableName}];")));
+                    string.Concat(ProjectionTableNames.Select(tableName => $"DELETE FROM [ElasticSearchProjections].[{tableName}];")));
         }
 
         private void PrepareIndex(IElasticClient client, bool deleteIndex)

--- a/src/OrganisationRegistry.ElasticSearch.Projections/People/PeopleRunner.cs
+++ b/src/OrganisationRegistry.ElasticSearch.Projections/People/PeopleRunner.cs
@@ -18,7 +18,6 @@ namespace OrganisationRegistry.ElasticSearch.Projections.People
 
         public new static readonly Type[] EventHandlers =
         {
-            typeof(MemoryCachesMaintainer),
             typeof(CachedOrganisationForBodies),
             typeof(Person),
             typeof(PersonFunction),

--- a/src/OrganisationRegistry.SqlServer/ElasticSearchProjections/BodyCacheItem.cs
+++ b/src/OrganisationRegistry.SqlServer/ElasticSearchProjections/BodyCacheItem.cs
@@ -1,0 +1,28 @@
+namespace OrganisationRegistry.SqlServer.ElasticSearchProjections
+{
+    using System;
+    using Infrastructure;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Metadata.Builders;
+    using SqlServer;
+
+    public class BodyCacheItem
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class BodyCacheForEsConfiguration : EntityMappingConfiguration<BodyCacheItem>
+    {
+        public const string TableName = "BodyCache";
+
+        public override void Map(EntityTypeBuilder<BodyCacheItem> b)
+        {
+            b.ToTable(TableName, WellknownSchemas.ElasticSearchProjectionsSchema)
+                .HasKey(p => p.Id)
+                .IsClustered(false);
+
+            b.Property(p => p.Name).IsRequired();
+        }
+    }
+}

--- a/src/OrganisationRegistry.SqlServer/ElasticSearchProjections/BodySeatCacheItem.cs
+++ b/src/OrganisationRegistry.SqlServer/ElasticSearchProjections/BodySeatCacheItem.cs
@@ -1,0 +1,32 @@
+namespace OrganisationRegistry.SqlServer.ElasticSearchProjections
+{
+    using System;
+    using Infrastructure;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Metadata.Builders;
+    using SqlServer;
+
+    public class BodySeatCacheItem
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public string Number { get; set; }
+        public bool IsPaid { get; set; }
+    }
+
+    public class BodySeatCacheForEsConfiguration : EntityMappingConfiguration<BodySeatCacheItem>
+    {
+        public const string TableName = "BodySeatCache";
+
+        public override void Map(EntityTypeBuilder<BodySeatCacheItem> b)
+        {
+            b.ToTable(TableName, WellknownSchemas.ElasticSearchProjectionsSchema)
+                .HasKey(p => p.Id)
+                .IsClustered(false);
+
+            b.Property(p => p.Name).IsRequired();
+            b.Property(p => p.Number).IsRequired();
+            b.Property(p => p.IsPaid).IsRequired();
+        }
+    }
+}

--- a/src/OrganisationRegistry.SqlServer/ElasticSearchProjections/OrganisationCacheItem.cs
+++ b/src/OrganisationRegistry.SqlServer/ElasticSearchProjections/OrganisationCacheItem.cs
@@ -1,0 +1,29 @@
+namespace OrganisationRegistry.SqlServer.ElasticSearchProjections
+{
+    using System;
+    using Infrastructure;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+    public class OrganisationCacheItem
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public string OvoNumber { get; set; }
+    }
+
+    public class OrganisationCacheForEsConfiguration : EntityMappingConfiguration<OrganisationCacheItem>
+    {
+        public const string TableName = "OrganisationCache";
+
+        public override void Map(EntityTypeBuilder<OrganisationCacheItem> b)
+        {
+            b.ToTable(TableName, WellknownSchemas.ElasticSearchProjectionsSchema)
+                .HasKey(p => p.Id)
+                .IsClustered(false);
+
+            b.Property(p => p.Name).IsRequired();
+            b.Property(p => p.OvoNumber).IsRequired();
+        }
+    }
+}

--- a/src/OrganisationRegistry.SqlServer/Infrastructure/OrganisationRegistryContext.cs
+++ b/src/OrganisationRegistry.SqlServer/Infrastructure/OrganisationRegistryContext.cs
@@ -136,6 +136,11 @@ namespace OrganisationRegistry.SqlServer.Infrastructure
         public DbSet<ElasticSearchProjections.OrganisationPerBody> OrganisationPerBodyListForES { get; set; }
         public DbSet<OrganisationToRebuild> OrganisationsToRebuild { get; set; }
 
+        public DbSet<OrganisationCacheItem> OrganisationCache { get; set; }
+        public DbSet<BodySeatCacheItem> BodySeatCache { get; set; }
+        public DbSet<BodyCacheItem> BodyCache { get; set; }
+
+
         // Reporting
         public DbSet<BodySeatGenderRatioOrganisationPerBodyListItem> BodySeatGenderRatioOrganisationPerBodyList { get; set; }
         public DbSet<BodySeatGenderRatioPersonListItem> BodySeatGenderRatioPersonList { get; set; }

--- a/src/OrganisationRegistry.SqlServer/Migrations/20210503121826_AddCachesForEs.Designer.cs
+++ b/src/OrganisationRegistry.SqlServer/Migrations/20210503121826_AddCachesForEs.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OrganisationRegistry.SqlServer.Infrastructure;
 
 namespace OrganisationRegistry.SqlServer.Migrations
 {
     [DbContext(typeof(OrganisationRegistryContext))]
-    partial class OrganisationRegistryContextModelSnapshot : ModelSnapshot
+    [Migration("20210503121826_AddCachesForEs")]
+    partial class AddCachesForEs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OrganisationRegistry.SqlServer/Migrations/20210503121826_AddCachesForEs.cs
+++ b/src/OrganisationRegistry.SqlServer/Migrations/20210503121826_AddCachesForEs.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace OrganisationRegistry.SqlServer.Migrations
+{
+    public partial class AddCachesForEs : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "BodyCache",
+                schema: "ElasticSearchProjections",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BodyCache", x => x.Id)
+                        .Annotation("SqlServer:Clustered", false);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "BodySeatCache",
+                schema: "ElasticSearchProjections",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Number = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    IsPaid = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BodySeatCache", x => x.Id)
+                        .Annotation("SqlServer:Clustered", false);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OrganisationCache",
+                schema: "ElasticSearchProjections",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    OvoNumber = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OrganisationCache", x => x.Id)
+                        .Annotation("SqlServer:Clustered", false);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "BodyCache",
+                schema: "ElasticSearchProjections");
+
+            migrationBuilder.DropTable(
+                name: "BodySeatCache",
+                schema: "ElasticSearchProjections");
+
+            migrationBuilder.DropTable(
+                name: "OrganisationCache",
+                schema: "ElasticSearchProjections");
+        }
+    }
+}

--- a/test/OrganisationRegistry.ElasticSearch.Tests/BodyHandlerTests.cs
+++ b/test/OrganisationRegistry.ElasticSearch.Tests/BodyHandlerTests.cs
@@ -28,9 +28,6 @@ namespace OrganisationRegistry.ElasticSearch.Tests
 
         public BodyHandlerTests(ElasticSearchFixture fixture)
         {
-            var memoryCaches = new Mock<IMemoryCaches>();
-            memoryCaches.Setup(caches => caches.ContactTypeNames[It.IsAny<Guid>()]).Returns("contact type");
-
             _fixture = fixture;
             _handler = new BodyHandler(
                 logger: _fixture.LoggerFactory.CreateLogger<BodyHandler>(),

--- a/test/OrganisationRegistry.ElasticSearch.Tests/BodyHandlerTests.cs
+++ b/test/OrganisationRegistry.ElasticSearch.Tests/BodyHandlerTests.cs
@@ -36,8 +36,7 @@ namespace OrganisationRegistry.ElasticSearch.Tests
                 logger: _fixture.LoggerFactory.CreateLogger<BodyHandler>(),
                 elastic: _fixture.Elastic,
                 contextFactory: _fixture.ContextFactory,
-                elasticSearchOptions: _fixture.ElasticSearchOptions,
-                memoryCaches: memoryCaches.Object);
+                elasticSearchOptions: _fixture.ElasticSearchOptions);
         }
 
         [EnvVarIgnoreFact]

--- a/test/OrganisationRegistry.ElasticSearch.Tests/PersonHandlerTests.cs
+++ b/test/OrganisationRegistry.ElasticSearch.Tests/PersonHandlerTests.cs
@@ -34,10 +34,6 @@ namespace OrganisationRegistry.ElasticSearch.Tests
         {
             _fixture = fixture;
 
-            var memoryCaches = new Mock<IMemoryCaches>();
-            memoryCaches.Setup(caches => caches.OrganisationNames[It.IsAny<Guid>()]).Returns("org name");
-            memoryCaches.Setup(caches => caches.ContactTypeNames[It.IsAny<Guid>()]).Returns("contact type name");
-
             var personHandler = new Person(
                 logger: _fixture.LoggerFactory.CreateLogger<Person>(),
                 elastic: _fixture.Elastic,
@@ -52,7 +48,6 @@ namespace OrganisationRegistry.ElasticSearch.Tests
             var serviceProvider = new ServiceCollection()
                 .AddSingleton(personHandler)
                 .AddSingleton(personCapacityHandler)
-                .AddSingleton(new MemoryCachesMaintainer(new MemoryCaches(fixture.ContextFactory), fixture.ContextFactory))
                 .BuildServiceProvider();
 
             _inProcessBus = new InProcessBus(new NullLogger<InProcessBus>(), new SecurityService(fixture.ContextFactory.Create()));

--- a/test/OrganisationRegistry.ElasticSearch.Tests/PersonHandlerTests.cs
+++ b/test/OrganisationRegistry.ElasticSearch.Tests/PersonHandlerTests.cs
@@ -47,8 +47,7 @@ namespace OrganisationRegistry.ElasticSearch.Tests
             var personCapacityHandler = new PersonCapacity(
                 logger: _fixture.LoggerFactory.CreateLogger<PersonCapacity>(),
                 elastic: _fixture.Elastic,
-                contextFactory: _fixture.ContextFactory,
-                memoryCaches.Object);
+                contextFactory: _fixture.ContextFactory);
 
             var serviceProvider = new ServiceCollection()
                 .AddSingleton(personHandler)


### PR DESCRIPTION
Memory caches depend on the projections for the UI api. There's a real
risk that the ES projections will use the memory caches at a point where
the memory cache is not in a good state (rebuilds, bugs, ...).

Instead we introduce a separate cache used by ES projections runner,
to be run before running any other ES projections so we know it's
up to date.