### PR TITLE
Fix people show on vlaanderen

### DIFF
--- a/src/OrganisationRegistry.Api/Organisation/OrganisationKboController.cs
+++ b/src/OrganisationRegistry.Api/Organisation/OrganisationKboController.cs
@@ -53,8 +53,7 @@ namespace OrganisationRegistry.Api.Organisation
         {
             await CommandSender.Send(
                 new CancelCouplingWithKbo(
-                    new OrganisationId(id),
-                    User));
+                    new OrganisationId(id)));
 
             return Ok();
         }

--- a/src/OrganisationRegistry.Api/Task/TaskController.cs
+++ b/src/OrganisationRegistry.Api/Task/TaskController.cs
@@ -17,6 +17,7 @@ namespace OrganisationRegistry.Api.Task
     using SqlServer.Infrastructure;
     using OrganisationRegistry.Body;
     using OrganisationRegistry.Body.Commands;
+    using OrganisationRegistry.Infrastructure.Authorization;
 
     [ApiVersion("1.0")]
     [AdvertiseApiVersions("1.0")]
@@ -40,6 +41,7 @@ namespace OrganisationRegistry.Api.Task
         public async Task<IActionResult> Post(
             [FromServices] Func<Owned<OrganisationRegistryContext>> contextFactory,
             [FromServices] IKboSync kboSync,
+            [FromServices] ISecurityService securityService,
             [FromBody] TaskRequest task)
         {
             if (!ModelState.IsValid)
@@ -48,7 +50,7 @@ namespace OrganisationRegistry.Api.Task
             switch (task.Type)
             {
                 case TaskType.CheckIfDayHasPassed:
-                    await CommandSender.Send(new CheckIfDayHasPassed());
+                    await CommandSender.Send(new CheckIfDayHasPassed {User = securityService.GetUser(User)});
                     break;
 
                 case TaskType.RebuildProjection:

--- a/src/OrganisationRegistry.Infrastructure/Bus/NullPublisher.cs
+++ b/src/OrganisationRegistry.Infrastructure/Bus/NullPublisher.cs
@@ -2,6 +2,7 @@ namespace OrganisationRegistry.Infrastructure.Bus
 {
     using System.Data.Common;
     using System.Threading.Tasks;
+    using Authorization;
     using Events;
 
     public class NullPublisher : IEventPublisher
@@ -12,6 +13,6 @@ namespace OrganisationRegistry.Infrastructure.Bus
             return Task.CompletedTask;
         }
 
-        public async Task ProcessReactions<T>(IEnvelope<T> envelope) where T : IEvent<T> { }
+        public async Task ProcessReactions<T>(IEnvelope<T> envelope, IUser user) where T : IEvent<T> {}
     }
 }

--- a/src/OrganisationRegistry.Infrastructure/Domain/IRepository.cs
+++ b/src/OrganisationRegistry.Infrastructure/Domain/IRepository.cs
@@ -2,10 +2,11 @@
 {
     using System;
     using System.Threading.Tasks;
+    using Authorization;
 
     public interface IRepository
     {
-        Task Save<T>(T aggregate, int? expectedVersion = null) where T : AggregateRoot;
+        Task Save<T>(T aggregate, int? expectedVersion = null, IUser? user = null) where T : AggregateRoot;
 
         T Get<T>(Guid aggregateId) where T : AggregateRoot;
     }

--- a/src/OrganisationRegistry.Infrastructure/Domain/IRepository.cs
+++ b/src/OrganisationRegistry.Infrastructure/Domain/IRepository.cs
@@ -6,7 +6,7 @@
 
     public interface IRepository
     {
-        Task Save<T>(T aggregate, int? expectedVersion = null, IUser? user = null) where T : AggregateRoot;
+        Task Save<T>(T aggregate, IUser user, int? expectedVersion = null) where T : AggregateRoot;
 
         T Get<T>(Guid aggregateId) where T : AggregateRoot;
     }

--- a/src/OrganisationRegistry.Infrastructure/Domain/ISession.cs
+++ b/src/OrganisationRegistry.Infrastructure/Domain/ISession.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Threading.Tasks;
+    using Authorization;
 
     public interface ISession
     {
@@ -9,6 +10,6 @@
 
         T Get<T>(Guid id, int? expectedVersion = null) where T : AggregateRoot;
 
-        Task Commit();
+        Task Commit(IUser? user = null);
     }
 }

--- a/src/OrganisationRegistry.Infrastructure/Domain/ISession.cs
+++ b/src/OrganisationRegistry.Infrastructure/Domain/ISession.cs
@@ -10,6 +10,6 @@
 
         T Get<T>(Guid id, int? expectedVersion = null) where T : AggregateRoot;
 
-        Task Commit(IUser? user = null);
+        Task Commit(IUser user);
     }
 }

--- a/src/OrganisationRegistry.Infrastructure/Domain/Repository.cs
+++ b/src/OrganisationRegistry.Infrastructure/Domain/Repository.cs
@@ -6,6 +6,7 @@ namespace OrganisationRegistry.Infrastructure.Domain
     using Factories;
     using System.Linq;
     using System.Threading.Tasks;
+    using Authorization;
     using EventStore;
     using Microsoft.Extensions.Logging;
 
@@ -23,13 +24,13 @@ namespace OrganisationRegistry.Infrastructure.Domain
             logger.LogTrace("Creating Repository.");
         }
 
-        public async Task Save<T>(T aggregate, int? expectedVersion = null) where T : AggregateRoot
+        public async Task Save<T>(T aggregate, int? expectedVersion = null, IUser user = null) where T : AggregateRoot
         {
             if (expectedVersion != null && _eventStore.Get<T>(aggregate.Id, expectedVersion.Value).Any())
                 throw new ConcurrencyException(aggregate.Id, expectedVersion.Value);
 
             var changes = aggregate.FlushUncommitedChanges();
-            await _eventStore.Save<T>(changes);
+            await _eventStore.Save<T>(changes, user);
         }
 
         public T Get<T>(Guid aggregateId) where T : AggregateRoot

--- a/src/OrganisationRegistry.Infrastructure/Domain/Repository.cs
+++ b/src/OrganisationRegistry.Infrastructure/Domain/Repository.cs
@@ -24,7 +24,7 @@ namespace OrganisationRegistry.Infrastructure.Domain
             logger.LogTrace("Creating Repository.");
         }
 
-        public async Task Save<T>(T aggregate, int? expectedVersion = null, IUser user = null) where T : AggregateRoot
+        public async Task Save<T>(T aggregate, IUser user, int? expectedVersion = null) where T : AggregateRoot
         {
             if (expectedVersion != null && _eventStore.Get<T>(aggregate.Id, expectedVersion.Value).Any())
                 throw new ConcurrencyException(aggregate.Id, expectedVersion.Value);

--- a/src/OrganisationRegistry.Infrastructure/Domain/Session.cs
+++ b/src/OrganisationRegistry.Infrastructure/Domain/Session.cs
@@ -3,6 +3,7 @@ namespace OrganisationRegistry.Infrastructure.Domain
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using Authorization;
     using Exception;
     using Microsoft.Extensions.Logging;
 
@@ -54,10 +55,10 @@ namespace OrganisationRegistry.Infrastructure.Domain
         private bool IsTracked(Guid id)
             => _trackedAggregates.ContainsKey(id);
 
-        public async Task Commit()
+        public async Task Commit(IUser user = null)
         {
             foreach (var descriptor in _trackedAggregates.Values)
-                await _repository.Save(descriptor.Aggregate, descriptor.Version);
+                await _repository.Save(descriptor.Aggregate, descriptor.Version, user);
 
             Reset();
         }

--- a/src/OrganisationRegistry.Infrastructure/Domain/Session.cs
+++ b/src/OrganisationRegistry.Infrastructure/Domain/Session.cs
@@ -55,10 +55,10 @@ namespace OrganisationRegistry.Infrastructure.Domain
         private bool IsTracked(Guid id)
             => _trackedAggregates.ContainsKey(id);
 
-        public async Task Commit(IUser user = null)
+        public async Task Commit(IUser user)
         {
             foreach (var descriptor in _trackedAggregates.Values)
-                await _repository.Save(descriptor.Aggregate, descriptor.Version, user);
+                await _repository.Save(descriptor.Aggregate, user, descriptor.Version);
 
             Reset();
         }

--- a/src/OrganisationRegistry.Infrastructure/EventStore/SqlServerEventStore.cs
+++ b/src/OrganisationRegistry.Infrastructure/EventStore/SqlServerEventStore.cs
@@ -98,13 +98,12 @@ IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'IX_Events_Number' AND obj
             }
         }
 
-        public async Task Save<T>(IEnumerable<IEvent> events, IUser? user = null)
+        public async Task Save<T>(IEnumerable<IEvent> events, IUser user)
         {
             var eventsToSave = events.ToList();
             if (eventsToSave.Count == 0)
                 return;
 
-            user ??= _securityService.GetUser(ClaimsPrincipal.Current);
             var ip = user.Ip;
             var firstName = user.FirstName;
             var lastName = user.LastName;

--- a/src/OrganisationRegistry.Infrastructure/EventStore/SqlServerEventStore.cs
+++ b/src/OrganisationRegistry.Infrastructure/EventStore/SqlServerEventStore.cs
@@ -98,13 +98,13 @@ IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'IX_Events_Number' AND obj
             }
         }
 
-        public async Task Save<T>(IEnumerable<IEvent> events)
+        public async Task Save<T>(IEnumerable<IEvent> events, IUser? user = null)
         {
             var eventsToSave = events.ToList();
             if (eventsToSave.Count == 0)
                 return;
 
-            var user = _securityService.GetUser(ClaimsPrincipal.Current);
+            user ??= _securityService.GetUser(ClaimsPrincipal.Current);
             var ip = user.Ip;
             var firstName = user.FirstName;
             var lastName = user.LastName;

--- a/src/OrganisationRegistry.Infrastructure/Events/IEventPublisher.cs
+++ b/src/OrganisationRegistry.Infrastructure/Events/IEventPublisher.cs
@@ -2,11 +2,12 @@
 {
     using System.Data.Common;
     using System.Threading.Tasks;
+    using Authorization;
 
     public interface IEventPublisher
     {
         Task Publish<T>(DbConnection dbConnection, DbTransaction dbTransaction, IEnvelope<T> envelope) where T : IEvent<T>;
 
-        Task ProcessReactions<T>(IEnvelope<T> envelope) where T : IEvent<T>;
+        Task ProcessReactions<T>(IEnvelope<T> envelope, IUser user) where T : IEvent<T>;
     }
 }

--- a/src/OrganisationRegistry.Infrastructure/Events/IEventStore.cs
+++ b/src/OrganisationRegistry.Infrastructure/Events/IEventStore.cs
@@ -7,7 +7,7 @@ namespace OrganisationRegistry.Infrastructure.Events
 
     public interface IEventStore
     {
-        Task Save<T>(IEnumerable<IEvent> events, IUser? user = null);
+        Task Save<T>(IEnumerable<IEvent> events, IUser user);
 
         IEnumerable<IEvent> Get<T>(Guid aggregateId, int fromVersion);
 

--- a/src/OrganisationRegistry.Infrastructure/Events/IEventStore.cs
+++ b/src/OrganisationRegistry.Infrastructure/Events/IEventStore.cs
@@ -3,10 +3,11 @@ namespace OrganisationRegistry.Infrastructure.Events
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using Authorization;
 
     public interface IEventStore
     {
-        Task Save<T>(IEnumerable<IEvent> events);
+        Task Save<T>(IEnumerable<IEvent> events, IUser? user = null);
 
         IEnumerable<IEvent> Get<T>(Guid aggregateId, int fromVersion);
 

--- a/src/OrganisationRegistry.Infrastructure/Snapshots/SnapshotRepository.cs
+++ b/src/OrganisationRegistry.Infrastructure/Snapshots/SnapshotRepository.cs
@@ -28,10 +28,10 @@ namespace OrganisationRegistry.Infrastructure.Snapshots
             _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
         }
 
-        public async Task Save<T>(T aggregate, int? expectedVersion = null, IUser? user = null) where T : AggregateRoot
+        public async Task Save<T>(T aggregate, IUser user, int? expectedVersion = null) where T : AggregateRoot
         {
             TryMakeSnapshot(aggregate);
-            await _repository.Save(aggregate, expectedVersion);
+            await _repository.Save(aggregate, user, expectedVersion);
         }
 
         public T Get<T>(Guid aggregateId) where T : AggregateRoot

--- a/src/OrganisationRegistry.Infrastructure/Snapshots/SnapshotRepository.cs
+++ b/src/OrganisationRegistry.Infrastructure/Snapshots/SnapshotRepository.cs
@@ -7,6 +7,7 @@ namespace OrganisationRegistry.Infrastructure.Snapshots
     using Infrastructure;
     using System.Linq;
     using System.Threading.Tasks;
+    using Authorization;
 
     public class SnapshotRepository : IRepository
     {
@@ -27,7 +28,7 @@ namespace OrganisationRegistry.Infrastructure.Snapshots
             _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
         }
 
-        public async Task Save<T>(T aggregate, int? expectedVersion = null) where T : AggregateRoot
+        public async Task Save<T>(T aggregate, int? expectedVersion = null, IUser? user = null) where T : AggregateRoot
         {
             TryMakeSnapshot(aggregate);
             await _repository.Save(aggregate, expectedVersion);

--- a/src/OrganisationRegistry.SqlServer/Migrations/20210809120034_AddIsActiveToOrganisationCapacity.Designer.cs
+++ b/src/OrganisationRegistry.SqlServer/Migrations/20210809120034_AddIsActiveToOrganisationCapacity.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OrganisationRegistry.SqlServer.Infrastructure;
 
 namespace OrganisationRegistry.SqlServer.Migrations
 {
     [DbContext(typeof(OrganisationRegistryContext))]
-    partial class OrganisationRegistryContextModelSnapshot : ModelSnapshot
+    [Migration("20210809120034_AddIsActiveToOrganisationCapacity")]
+    partial class AddIsActiveToOrganisationCapacity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OrganisationRegistry.SqlServer/Migrations/20210809120034_AddIsActiveToOrganisationCapacity.cs
+++ b/src/OrganisationRegistry.SqlServer/Migrations/20210809120034_AddIsActiveToOrganisationCapacity.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace OrganisationRegistry.SqlServer.Migrations
+{
+    public partial class AddIsActiveToOrganisationCapacity : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsActive",
+                schema: "OrganisationRegistry",
+                table: "OrganisationCapacityList",
+                type: "bit",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsActive",
+                schema: "OrganisationRegistry",
+                table: "OrganisationCapacityList");
+        }
+    }
+}

--- a/src/OrganisationRegistry.SqlServer/Organisation/OrganisationDetailItemView.cs
+++ b/src/OrganisationRegistry.SqlServer/Organisation/OrganisationDetailItemView.cs
@@ -105,9 +105,7 @@ namespace OrganisationRegistry.SqlServer.Organisation
         IEventHandler<ParentAssignedToOrganisation>,
         IEventHandler<ParentClearedFromOrganisation>,
         IEventHandler<PurposeUpdated>,
-        IEventHandler<OrganisationTerminated>,
-        IReactionHandler<DayHasPassed>
-    {
+        IEventHandler<OrganisationTerminated>{
         private readonly IEventStore _eventStore;
         public override string[] ProjectionTableNames => Enum.GetNames(typeof(ProjectionTables));
 
@@ -372,19 +370,6 @@ namespace OrganisationRegistry.SqlServer.Organisation
             IEnvelope<RebuildProjection> message)
         {
             await RebuildProjection(_eventStore, dbConnection, dbTransaction, message);
-        }
-
-        public async Task<List<ICommand>> Handle(IEnvelope<DayHasPassed> message)
-        {
-            using (var context = ContextFactory.Create())
-            {
-                var organisationDetails = context.OrganisationDetail.ToList();
-                return organisationDetails
-                    .Select(item =>
-                        new UpdateRelationshipValidities(new OrganisationId(item.Id), message.Body.NextDate))
-                    .Cast<ICommand>()
-                    .ToList();
-            }
         }
     }
 }

--- a/src/OrganisationRegistry/Body/BodyCommandHandlers.cs
+++ b/src/OrganisationRegistry/Body/BodyCommandHandlers.cs
@@ -104,7 +104,7 @@ namespace OrganisationRegistry.Body
                 inActiveLifecyclePhaseType);
 
             Session.Add(body);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateBodyInfo message)
@@ -116,7 +116,7 @@ namespace OrganisationRegistry.Body
                 message.ShortName,
                 message.Description);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateBodyValidity message)
@@ -127,7 +127,7 @@ namespace OrganisationRegistry.Body
                 message.FormalValidity,
                 _dateTimeProvider);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateBodyBalancedParticipation message)
@@ -139,7 +139,7 @@ namespace OrganisationRegistry.Body
                 message.BalancedParticipationExtraRemark,
                 message.BalancedParticipationExceptionMeasure);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AddBodyFormalFramework message)
@@ -152,7 +152,7 @@ namespace OrganisationRegistry.Body
                 formalFramework,
                 message.Validity);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateBodyFormalFramework message)
@@ -165,7 +165,7 @@ namespace OrganisationRegistry.Body
                 formalFramework,
                 message.Validity);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AddBodyOrganisation message)
@@ -179,7 +179,7 @@ namespace OrganisationRegistry.Body
                 message.Validity,
                 _dateTimeProvider);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateBodyOrganisation message)
@@ -193,7 +193,7 @@ namespace OrganisationRegistry.Body
                 message.Validity,
                 _dateTimeProvider);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateCurrentBodyOrganisation message)
@@ -201,7 +201,7 @@ namespace OrganisationRegistry.Body
             var body = Session.Get<Body>(message.BodyId);
             body.UpdateCurrentOrganisation(_dateTimeProvider.Today);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AddBodyLifecyclePhase message)
@@ -214,7 +214,7 @@ namespace OrganisationRegistry.Body
                 lifecyclePhaseType,
                 message.Validity);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateBodyLifecyclePhase message)
@@ -227,7 +227,7 @@ namespace OrganisationRegistry.Body
                 lifecyclePhaseType,
                 message.Validity);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AddBodySeat message)
@@ -245,7 +245,7 @@ namespace OrganisationRegistry.Body
                 message.EntitledToVote,
                 message.Validity);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateBodySeat message)
@@ -261,7 +261,7 @@ namespace OrganisationRegistry.Body
                 message.EntitledToVote,
                 message.Validity);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AssignBodyNumber message)
@@ -270,7 +270,7 @@ namespace OrganisationRegistry.Body
 
             body.AssignBodyNumber(_bodyNumberGenerator.GenerateNumber());
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AssignBodySeatNumber message)
@@ -282,7 +282,7 @@ namespace OrganisationRegistry.Body
                 message.BodySeatId,
                 bodySeatNumber);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AssignPersonToBodySeat message)
@@ -303,7 +303,7 @@ namespace OrganisationRegistry.Body
                 contacts,
                 message.Validity);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AssignFunctionTypeToBodySeat message)
@@ -319,7 +319,7 @@ namespace OrganisationRegistry.Body
                 message.BodySeatId,
                 message.Validity);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AssignOrganisationToBodySeat message)
@@ -333,7 +333,7 @@ namespace OrganisationRegistry.Body
                 message.BodySeatId,
                 message.Validity);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(ReassignPersonToBodySeat message)
@@ -354,7 +354,7 @@ namespace OrganisationRegistry.Body
                 contacts,
                 message.Validity);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(ReassignFunctionTypeToBodySeat message)
@@ -370,7 +370,7 @@ namespace OrganisationRegistry.Body
                 message.BodySeatId,
                 message.Validity);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(ReassignOrganisationToBodySeat message)
@@ -384,7 +384,7 @@ namespace OrganisationRegistry.Body
                 message.BodySeatId,
                 message.Validity);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AddDelegationAssignment message)
@@ -407,7 +407,7 @@ namespace OrganisationRegistry.Body
                 message.Validity,
                 _dateTimeProvider.Today);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateDelegationAssignment message)
@@ -430,7 +430,7 @@ namespace OrganisationRegistry.Body
                 message.Validity,
                 _dateTimeProvider.Today);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateCurrentPersonAssignedToBodyMandate message)
@@ -442,7 +442,7 @@ namespace OrganisationRegistry.Body
                 message.BodyMandateId,
                 _dateTimeProvider.Today);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(RemoveDelegationAssignment message)
@@ -455,7 +455,7 @@ namespace OrganisationRegistry.Body
                 message.DelegationAssignmentId,
                 _dateTimeProvider.Today);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AddBodyContact message)
@@ -469,7 +469,7 @@ namespace OrganisationRegistry.Body
                 message.ContactValue,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateBodyContact message)
@@ -483,7 +483,7 @@ namespace OrganisationRegistry.Body
                 message.Value,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AddBodyBodyClassification message)
@@ -498,7 +498,7 @@ namespace OrganisationRegistry.Body
                 bodyClassification,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateBodyBodyClassification message)
@@ -513,7 +513,7 @@ namespace OrganisationRegistry.Body
                 bodyClassification,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/BodyClassification/BodyClassificationCommandHandlers.cs
+++ b/src/OrganisationRegistry/BodyClassification/BodyClassificationCommandHandlers.cs
@@ -31,7 +31,7 @@ namespace OrganisationRegistry.BodyClassification
 
             var bodyClassification = new BodyClassification(message.BodyClassificationId, message.Name, message.Order, message.Active, bodyClassificationType);
             Session.Add(bodyClassification);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateBodyClassification message)
@@ -42,7 +42,7 @@ namespace OrganisationRegistry.BodyClassification
             var bodyClassificationType = Session.Get<BodyClassificationType>(message.BodyClassificationTypeId);
             var bodyClassification = Session.Get<BodyClassification>(message.BodyClassificationId);
             bodyClassification.Update(message.Name, message.Order, message.Active, bodyClassificationType);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/BodyClassificationType/BodyClassificationTypeCommandHandlers.cs
+++ b/src/OrganisationRegistry/BodyClassificationType/BodyClassificationTypeCommandHandlers.cs
@@ -28,7 +28,7 @@ namespace OrganisationRegistry.BodyClassificationType
 
             var bodyClassificationType = new BodyClassificationType(message.BodyClassificationTypeId, message.Name);
             Session.Add(bodyClassificationType);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateBodyClassificationType message)
@@ -38,7 +38,7 @@ namespace OrganisationRegistry.BodyClassificationType
 
             var bodyClassificationType = Session.Get<BodyClassificationType>(message.BodyClassificationTypeId);
             bodyClassificationType.Update(message.Name);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/Building/BuildingCommandHandlers.cs
+++ b/src/OrganisationRegistry/Building/BuildingCommandHandlers.cs
@@ -28,7 +28,7 @@
 
             var building = new Building(message.BuildingId, message.Name, message.VimId);
             Session.Add(building);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateBuilding message)
@@ -38,7 +38,7 @@
 
             var building = Session.Get<Building>(message.BuildingId);
             building.Update(message.Name, message.VimId);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/Capacity/CapacityCommandHandlers.cs
+++ b/src/OrganisationRegistry/Capacity/CapacityCommandHandlers.cs
@@ -28,7 +28,7 @@
 
             var capacity = new Capacity(message.CapacityId, message.Name);
             Session.Add(capacity);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateCapacity message)
@@ -38,7 +38,7 @@
 
             var capacity = Session.Get<Capacity>(message.CapacityId);
             capacity.Update(message.Name);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/ContactType/ContactTypeCommandHandlers.cs
+++ b/src/OrganisationRegistry/ContactType/ContactTypeCommandHandlers.cs
@@ -28,7 +28,7 @@
 
             var contactType = new ContactType(message.ContactTypeId, message.Name);
             Session.Add(contactType);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateContactType message)
@@ -38,7 +38,7 @@
 
             var contactType = Session.Get<ContactType>(message.ContactTypeId);
             contactType.Update(message.Name);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/Day/DayCommandHandlers.cs
+++ b/src/OrganisationRegistry/Day/DayCommandHandlers.cs
@@ -34,7 +34,7 @@ namespace OrganisationRegistry.Day
                 Session.Add(day);
             }
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/FormalFramework/FormalFrameworkCommandHandlers.cs
+++ b/src/OrganisationRegistry/FormalFramework/FormalFrameworkCommandHandlers.cs
@@ -37,7 +37,7 @@ namespace OrganisationRegistry.FormalFramework
 
             var formalFramework = new FormalFramework(message.FormalFrameworkId, message.Name, message.Code, formalFrameworkCategory);
             Session.Add(formalFramework);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateFormalFramework message)
@@ -52,7 +52,7 @@ namespace OrganisationRegistry.FormalFramework
 
             var formalFramework = Session.Get<FormalFramework>(message.FormalFrameworkId);
             formalFramework.Update(message.Name, message.Code, formalFrameworkCategory);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/FormalFrameworkCategory/FormalFrameworkCategoryCommandHandlers.cs
+++ b/src/OrganisationRegistry/FormalFrameworkCategory/FormalFrameworkCategoryCommandHandlers.cs
@@ -28,7 +28,7 @@
 
             var formalFrameworkCategory = new FormalFrameworkCategory(message.FormalFrameworkCategoryId, message.Name);
             Session.Add(formalFrameworkCategory);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateFormalFrameworkCategory message)
@@ -38,7 +38,7 @@
 
             var formalFrameworkCategory = Session.Get<FormalFrameworkCategory>(message.FormalFrameworkCategoryId);
             formalFrameworkCategory.Update(message.Name);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/Function/FunctionTypeCommandHandlers.cs
+++ b/src/OrganisationRegistry/Function/FunctionTypeCommandHandlers.cs
@@ -29,7 +29,7 @@
             var functionType = new FunctionType(message.FunctionTypeId, message.Name);
 
             Session.Add(functionType);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateFunctionType message)
@@ -40,7 +40,7 @@
             var functionType = Session.Get<FunctionType>(message.FunctionTypeId);
 
             functionType.Update(message.Name);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/Infrastructure/InfrastructureCommandHandlers.cs
+++ b/src/OrganisationRegistry/Infrastructure/InfrastructureCommandHandlers.cs
@@ -30,7 +30,7 @@
                 projection.RebuildProjection(message.ProjectionName);
             }
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/KeyTypes/KeyTypeCommandHandlers.cs
+++ b/src/OrganisationRegistry/KeyTypes/KeyTypeCommandHandlers.cs
@@ -28,7 +28,7 @@
 
             var keyType = new KeyType(message.KeyTypeId, message.Name);
             Session.Add(keyType);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateKeyType message)
@@ -38,7 +38,7 @@
 
             var keyType = Session.Get<KeyType>(message.KeyTypeId);
             keyType.Update(message.Name);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/LabelType/LabelTypeCommandHandlers.cs
+++ b/src/OrganisationRegistry/LabelType/LabelTypeCommandHandlers.cs
@@ -28,7 +28,7 @@
 
             var labelType = new LabelType(message.LabelTypeId, message.Name);
             Session.Add(labelType);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateLabelType message)
@@ -38,7 +38,7 @@
 
             var labelType = Session.Get<LabelType>(message.LabelTypeId);
             labelType.Update(message.Name);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/LifecyclePhaseType/LifecyclePhaseTypeCommandHandlers.cs
+++ b/src/OrganisationRegistry/LifecyclePhaseType/LifecyclePhaseTypeCommandHandlers.cs
@@ -39,7 +39,7 @@
                 message.Status);
 
             Session.Add(lifecyclePhaseType);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateLifecyclePhaseType message)
@@ -57,7 +57,7 @@
                 message.LifecyclePhaseTypeIsRepresentativeFor,
                 message.Status);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/Location/LocationCommandHandlers.cs
+++ b/src/OrganisationRegistry/Location/LocationCommandHandlers.cs
@@ -28,7 +28,7 @@
 
             var location = new Location(message.LocationId, message.CrabLocationId, message.Address);
             Session.Add(location);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateLocation message)
@@ -38,7 +38,7 @@
 
             var location = Session.Get<Location>(message.LocationId);
             location.Update(message.CrabLocationId, message.Address);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/LocationType/LocationTypeCommandHandlers.cs
+++ b/src/OrganisationRegistry/LocationType/LocationTypeCommandHandlers.cs
@@ -28,7 +28,7 @@
 
             var locationType = new LocationType(message.LocationTypeId, message.Name);
             Session.Add(locationType);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateLocationType message)
@@ -38,7 +38,7 @@
 
             var locationType = Session.Get<LocationType>(message.LocationTypeId);
             locationType.Update(message.Name);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/MandateRoleType/MandateRoleTypeCommandHandlers.cs
+++ b/src/OrganisationRegistry/MandateRoleType/MandateRoleTypeCommandHandlers.cs
@@ -28,7 +28,7 @@
 
             var mandateRoleType = new MandateRoleType(message.MandateRoleTypeId, message.Name);
             Session.Add(mandateRoleType);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateMandateRoleType message)
@@ -38,7 +38,7 @@
 
             var mandateRoleType = Session.Get<MandateRoleType>(message.MandateRoleTypeId);
             mandateRoleType.Update(message.Name);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/Organisation/Commands/CancelCouplingWithKbo.cs
+++ b/src/OrganisationRegistry/Organisation/Commands/CancelCouplingWithKbo.cs
@@ -1,20 +1,14 @@
 namespace OrganisationRegistry.Organisation.Commands
 {
-    using System.Security.Claims;
-
     public class CancelCouplingWithKbo : BaseCommand<OrganisationId>
     {
         public OrganisationId OrganisationId => Id;
 
-        public ClaimsPrincipal User { get; }
 
         public CancelCouplingWithKbo(
-            OrganisationId organisationId,
-            ClaimsPrincipal user)
+            OrganisationId organisationId)
         {
             Id = organisationId;
-
-            User = user;
         }
     }
 }

--- a/src/OrganisationRegistry/Organisation/KboOrganisationCommandHandlers.cs
+++ b/src/OrganisationRegistry/Organisation/KboOrganisationCommandHandlers.cs
@@ -98,7 +98,7 @@ namespace OrganisationRegistry.Organisation
 
             var location = GetOrAddLocations(kboOrganisation.Address);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
 
             var organisation = Organisation.CreateFromKbo(
                 message,
@@ -118,7 +118,7 @@ namespace OrganisationRegistry.Organisation
 
             AddLabel(organisation, kboOrganisation);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(CoupleOrganisationToKbo message)
@@ -159,7 +159,7 @@ namespace OrganisationRegistry.Organisation
 
             AddLabel(organisation, kboOrganisation);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(SyncOrganisationWithKbo message)
@@ -190,7 +190,7 @@ namespace OrganisationRegistry.Organisation
 
             var location = GetOrAddLocations(kboOrganisation.Address);
 
-            await Session.Commit();
+            await Session.Commit(user);
 
             // IMPORTANT: Need to re-Get the organisation, otherwise the Session will not properly handle the events.
             organisation = Session.Get<Organisation>(organisationId);
@@ -214,7 +214,7 @@ namespace OrganisationRegistry.Organisation
 
             organisation.MarkAsSynced(kboSyncItemId);
 
-            await Session.Commit();
+            await Session.Commit(user);
         }
 
         public async Task Handle(CancelCouplingWithKbo message)
@@ -223,7 +223,7 @@ namespace OrganisationRegistry.Organisation
 
             organisation.CancelCouplingWithKbo();
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(SyncOrganisationTerminationWithKbo message)
@@ -234,7 +234,7 @@ namespace OrganisationRegistry.Organisation
 
             organisation.SyncKboTermination();
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         private KboRegisteredOffice GetOrAddLocations(IMagdaAddress address)

--- a/src/OrganisationRegistry/Organisation/Organisation.cs
+++ b/src/OrganisationRegistry/Organisation/Organisation.cs
@@ -2487,7 +2487,9 @@ namespace OrganisationRegistry.Organisation
 
         public void ThrowIfTerminated(IUser user)
         {
-            if (IsTerminated && !user.IsInRole(Role.OrganisationRegistryBeheerder))
+            if (IsTerminated &&
+                !user.IsInRole(Role.OrganisationRegistryBeheerder) &&
+                !user.IsInRole(Role.AutomatedTask))
                 throw new OrganisationAlreadyTerminated();
         }
     }

--- a/src/OrganisationRegistry/Organisation/OrganisationCommandHandlers.cs
+++ b/src/OrganisationRegistry/Organisation/OrganisationCommandHandlers.cs
@@ -737,7 +737,7 @@ namespace OrganisationRegistry.Organisation
 
             organisation.UpdateRelationshipValidities(message.Date);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AddOrganisationOpeningHour message)

--- a/src/OrganisationRegistry/Organisation/OrganisationCommandHandlers.cs
+++ b/src/OrganisationRegistry/Organisation/OrganisationCommandHandlers.cs
@@ -115,7 +115,7 @@ namespace OrganisationRegistry.Organisation
                 _dateTimeProvider);
 
             Session.Add(organisation);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateOrganisationInfo message)
@@ -138,7 +138,7 @@ namespace OrganisationRegistry.Organisation
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)),
                 _dateTimeProvider);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AddOrganisationParent message)
@@ -158,7 +158,7 @@ namespace OrganisationRegistry.Organisation
                 validity,
                 _dateTimeProvider);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateOrganisationParent message)
@@ -178,7 +178,7 @@ namespace OrganisationRegistry.Organisation
                 validity,
                 _dateTimeProvider);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AddOrganisationFormalFramework message)
@@ -201,7 +201,7 @@ namespace OrganisationRegistry.Organisation
                 validity,
                 _dateTimeProvider);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateOrganisationFormalFramework message)
@@ -224,7 +224,7 @@ namespace OrganisationRegistry.Organisation
                 validity,
                 _dateTimeProvider);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         private bool ParentTreeHasOrganisationInIt(
@@ -276,7 +276,7 @@ namespace OrganisationRegistry.Organisation
                 message.KeyValue,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateOrganisationKey message)
@@ -291,7 +291,7 @@ namespace OrganisationRegistry.Organisation
                 message.Value,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
 
@@ -310,7 +310,7 @@ namespace OrganisationRegistry.Organisation
                 message.Description,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateOrganisationRegulation message)
@@ -328,7 +328,7 @@ namespace OrganisationRegistry.Organisation
                 message.Description,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AddOrganisationCapacity message)
@@ -357,7 +357,7 @@ namespace OrganisationRegistry.Organisation
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)),
                 _dateTimeProvider);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateOrganisationCapacity message)
@@ -386,7 +386,7 @@ namespace OrganisationRegistry.Organisation
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)),
                 _dateTimeProvider);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AddOrganisationFunction message)
@@ -410,7 +410,7 @@ namespace OrganisationRegistry.Organisation
                 contacts,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateOrganisationFunction message)
@@ -434,7 +434,7 @@ namespace OrganisationRegistry.Organisation
                 contacts,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AddOrganisationRelation message)
@@ -451,7 +451,7 @@ namespace OrganisationRegistry.Organisation
                 relatedOrganisation,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateOrganisationRelation message)
@@ -468,7 +468,7 @@ namespace OrganisationRegistry.Organisation
                 relatedOrganisation,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AddOrganisationBuilding message)
@@ -485,7 +485,7 @@ namespace OrganisationRegistry.Organisation
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)),
                 _dateTimeProvider);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateOrganisationBuilding message)
@@ -502,7 +502,7 @@ namespace OrganisationRegistry.Organisation
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)),
                 _dateTimeProvider);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AddOrganisationLocation message)
@@ -523,7 +523,7 @@ namespace OrganisationRegistry.Organisation
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)),
                 _dateTimeProvider);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateOrganisationLocation message)
@@ -544,7 +544,7 @@ namespace OrganisationRegistry.Organisation
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)),
                 _dateTimeProvider);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AddOrganisationContact message)
@@ -560,7 +560,7 @@ namespace OrganisationRegistry.Organisation
                 message.ContactValue,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateOrganisationContact message)
@@ -576,7 +576,7 @@ namespace OrganisationRegistry.Organisation
                 message.Value,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AddOrganisationLabel message)
@@ -594,7 +594,7 @@ namespace OrganisationRegistry.Organisation
                 message.LabelValue,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateOrganisationLabel message)
@@ -612,7 +612,7 @@ namespace OrganisationRegistry.Organisation
                 message.Value,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AddOrganisationOrganisationClassification message)
@@ -630,7 +630,7 @@ namespace OrganisationRegistry.Organisation
                 organisationClassification,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateOrganisationOrganisationClassification message)
@@ -649,7 +649,7 @@ namespace OrganisationRegistry.Organisation
                 organisationClassification,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(AddOrganisationBankAccount message)
@@ -668,7 +668,7 @@ namespace OrganisationRegistry.Organisation
                 bankAccountBic,
                 validity);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateOrganisationBankAccount message)
@@ -687,7 +687,7 @@ namespace OrganisationRegistry.Organisation
                 bankAccountBic,
                 validity);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateMainBuilding message)
@@ -697,7 +697,7 @@ namespace OrganisationRegistry.Organisation
 
             organisation.UpdateMainBuilding(_dateTimeProvider.Today);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateMainLocation message)
@@ -707,7 +707,7 @@ namespace OrganisationRegistry.Organisation
 
             organisation.UpdateMainLocation(_dateTimeProvider.Today);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateOrganisationFormalFrameworkParents message)
@@ -717,7 +717,7 @@ namespace OrganisationRegistry.Organisation
 
             organisation.UpdateOrganisationFormalFrameworkParent(_dateTimeProvider.Today, message.FormalFrameworkId);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateCurrentOrganisationParent message)
@@ -727,7 +727,7 @@ namespace OrganisationRegistry.Organisation
 
             organisation.UpdateCurrentOrganisationParent(_dateTimeProvider.Today);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateRelationshipValidities message)
@@ -752,7 +752,7 @@ namespace OrganisationRegistry.Organisation
                 message.DayOfWeek,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateOrganisationOpeningHour message)
@@ -767,7 +767,7 @@ namespace OrganisationRegistry.Organisation
                 message.DayOfWeek,
                 new Period(new ValidFrom(message.ValidFrom), new ValidTo(message.ValidTo)));
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(TerminateOrganisation message)
@@ -783,7 +783,7 @@ namespace OrganisationRegistry.Organisation
                 _dateTimeProvider,
                 message.ForceKboTermination);
 
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/OrganisationClassification/OrganisationClassificationCommandHandlers.cs
+++ b/src/OrganisationRegistry/OrganisationClassification/OrganisationClassificationCommandHandlers.cs
@@ -45,7 +45,7 @@ namespace OrganisationRegistry.OrganisationClassification
                     organisationClassificationType);
 
             Session.Add(organisationClassification);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateOrganisationClassification message)
@@ -60,7 +60,7 @@ namespace OrganisationRegistry.OrganisationClassification
             var organisationClassificationType = Session.Get<OrganisationClassificationType>(message.OrganisationClassificationTypeId);
             var organisationClassification = Session.Get<OrganisationClassification>(message.OrganisationClassificationId);
             organisationClassification.Update(message.Name, message.Order, message.ExternalKey, message.Active, organisationClassificationType);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/OrganisationClassificationType/OrganisationClassificationTypeCommandHandlers.cs
+++ b/src/OrganisationRegistry/OrganisationClassificationType/OrganisationClassificationTypeCommandHandlers.cs
@@ -28,7 +28,7 @@
 
             var organisationClassificationType = new OrganisationClassificationType(message.OrganisationClassificationTypeId, message.Name);
             Session.Add(organisationClassificationType);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateOrganisationClassificationType message)
@@ -38,7 +38,7 @@
 
             var organisationClassificationType = Session.Get<OrganisationClassificationType>(message.OrganisationClassificationTypeId);
             organisationClassificationType.Update(message.Name);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/OrganisationRelationType/OrganisationRelationTypeCommandHandlers.cs
+++ b/src/OrganisationRegistry/OrganisationRelationType/OrganisationRelationTypeCommandHandlers.cs
@@ -28,7 +28,7 @@ namespace OrganisationRegistry.OrganisationRelationType
 
             var organisationRelationType = new OrganisationRelationType(message.OrganisationRelationTypeId, message.Name, message.InverseName);
             Session.Add(organisationRelationType);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateOrganisationRelationType message)
@@ -38,7 +38,7 @@ namespace OrganisationRegistry.OrganisationRelationType
 
             var organisationRelationType = Session.Get<OrganisationRelationType>(message.OrganisationRelationTypeId);
             organisationRelationType.Update(message.Name, message.InverseName);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/Person/PersonCommandHandlers.cs
+++ b/src/OrganisationRegistry/Person/PersonCommandHandlers.cs
@@ -20,14 +20,14 @@
         {
             var person = new Person(message.PersonId, message.FirstName, message.Name, message.Sex, message.DateOfBirth);
             Session.Add(person);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdatePerson message)
         {
             var person = Session.Get<Person>(message.PersonId);
             person.Update(message.FirstName, message.Name, message.Sex, message.DateOfBirth);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/Purpose/PurposeCommandHandlers.cs
+++ b/src/OrganisationRegistry/Purpose/PurposeCommandHandlers.cs
@@ -28,7 +28,7 @@
 
             var purpose = new Purpose(message.PurposeId, message.Name);
             Session.Add(purpose);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdatePurpose message)
@@ -38,7 +38,7 @@
 
             var purpose = Session.Get<Purpose>(message.PurposeId);
             purpose.Update(message.Name);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/RegulationType/RegulationTypeCommandHandlers.cs
+++ b/src/OrganisationRegistry/RegulationType/RegulationTypeCommandHandlers.cs
@@ -28,7 +28,7 @@
 
             var regulationType = new RegulationType(message.RegulationTypeId, message.Name);
             Session.Add(regulationType);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateRegulationType message)
@@ -38,7 +38,7 @@
 
             var regulationType = Session.Get<RegulationType>(message.RegulationTypeId);
             regulationType.Update(message.Name);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/src/OrganisationRegistry/SeatType/SeatTypeCommandHandlers.cs
+++ b/src/OrganisationRegistry/SeatType/SeatTypeCommandHandlers.cs
@@ -28,7 +28,7 @@ namespace OrganisationRegistry.SeatType
 
             var seatType = new SeatType(message.SeatTypeId, message.Name, message.Order, message.IsEffective);
             Session.Add(seatType);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
 
         public async Task Handle(UpdateSeatType message)
@@ -38,7 +38,7 @@ namespace OrganisationRegistry.SeatType
 
             var seatType = Session.Get<SeatType>(message.SeatTypeId);
             seatType.Update(message.Name, message.Order, message.IsEffective);
-            await Session.Commit();
+            await Session.Commit(message.User);
         }
     }
 }

--- a/test/OrganisationRegistry.UnitTests/EventStore/SqlServerEventStoreTests.cs
+++ b/test/OrganisationRegistry.UnitTests/EventStore/SqlServerEventStoreTests.cs
@@ -8,11 +8,10 @@ namespace OrganisationRegistry.UnitTests
     using Microsoft.Extensions.Options;
     using Moq;
     using Newtonsoft.Json;
+    using OrganisationRegistry.Infrastructure.Authorization;
     using OrganisationRegistry.Infrastructure.Bus;
     using OrganisationRegistry.Infrastructure.Configuration;
-    using OrganisationRegistry.Infrastructure.Events;
     using OrganisationRegistry.Infrastructure.EventStore;
-    using OrganisationRegistry.Infrastructure.Infrastructure.Json;
     using OrganisationRegistry.Organisation.Events;
     using Xunit;
 
@@ -25,14 +24,15 @@ namespace OrganisationRegistry.UnitTests
             var lines = await File.ReadAllTextAsync(path);
             var eventData = JsonConvert.DeserializeObject<EventData[]>(lines);
 
-            var dataInterface = new Mock<IEventDataReader>();
-            dataInterface.Setup(i => i.GetEvents(It.IsAny<Guid>(), It.IsAny<int>()))
+            var dataReader = new Mock<IEventDataReader>();
+            dataReader.Setup(i => i.GetEvents(It.IsAny<Guid>(), It.IsAny<int>()))
                 .Returns(eventData.ToList());
 
             var sqlServerEventStore = new SqlServerEventStore(
                 new OptionsWrapper<InfrastructureConfiguration>(new InfrastructureConfiguration()),
                 new NullPublisher(),
-                dataInterface.Object);
+                new NotImplementedSecurityService(),
+                dataReader.Object);
 
             OrganisationInfoUpdatedFromKbo infoUpdatedFromKbo =
                 (OrganisationInfoUpdatedFromKbo) sqlServerEventStore

--- a/test/OrganisationRegistry.UnitTests/Infrastructure.Tests.Extensions/TestHelpers/SpecEventPublisher.cs
+++ b/test/OrganisationRegistry.UnitTests/Infrastructure.Tests.Extensions/TestHelpers/SpecEventPublisher.cs
@@ -3,6 +3,7 @@ namespace OrganisationRegistry.UnitTests.Infrastructure.Tests.Extensions.TestHel
     using System.Collections.Generic;
     using System.Data.Common;
     using System.Threading.Tasks;
+    using OrganisationRegistry.Infrastructure.Authorization;
     using OrganisationRegistry.Infrastructure.Events;
 
     internal class SpecEventPublisher : IEventPublisher
@@ -15,6 +16,8 @@ namespace OrganisationRegistry.UnitTests.Infrastructure.Tests.Extensions.TestHel
         public async Task Publish<T>(DbConnection dbConnection, DbTransaction dbTransaction, IEnvelope<T> envelope) where T : IEvent<T>
             => PublishedEvents.Add(envelope);
 
-        public async Task ProcessReactions<T>(IEnvelope<T> envelope) where T : IEvent<T> { }
+        public async Task ProcessReactions<T>(IEnvelope<T> envelope, IUser user) where T : IEvent<T>
+        {
+        }
     }
 }

--- a/test/OrganisationRegistry.UnitTests/Infrastructure.Tests.Extensions/TestHelpers/SpecEventStorage.cs
+++ b/test/OrganisationRegistry.UnitTests/Infrastructure.Tests.Extensions/TestHelpers/SpecEventStorage.cs
@@ -4,6 +4,7 @@ namespace OrganisationRegistry.UnitTests.Infrastructure.Tests.Extensions.TestHel
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using OrganisationRegistry.Infrastructure.Authorization;
     using OrganisationRegistry.Infrastructure.Events;
 
     internal class SpecEventStorage : IEventStore
@@ -18,7 +19,7 @@ namespace OrganisationRegistry.UnitTests.Infrastructure.Tests.Extensions.TestHel
             Events = events;
         }
 
-        public async Task Save<T>(IEnumerable<IEvent> events)
+        public async Task Save<T>(IEnumerable<IEvent> events, IUser user)
         {
             var eventList = events as IList<IEvent> ?? events.ToList();
             Events.AddRange(eventList);


### PR DESCRIPTION
Fixes a problem we had with multi-threadedness in reaction handlers. 

This decreases our dependency on ClaimsPrincipal, which does not work as well in our multi-threaded scenarios (eg: reaction handlers). We might consider moving away from the way reaction handlers work later, and replace them with hosted services on a cron schedule.