### PR TITLE
feat: make swagger docs work again

### DIFF
--- a/src/OrganisationRegistry.Api/Backoffice/Admin/Configuration/ConfigurationController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Admin/Configuration/ConfigurationController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Logging;
@@ -50,8 +51,8 @@
         /// <response code="200">If the configuration value is found.</response>
         /// <response code="404">If the configuration value cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(ConfigurationValue), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] ConfigurationContext context, [FromRoute] string id)
         {
             var configurationValue =
@@ -69,8 +70,8 @@
         /// <response code="201">If the configuration value is created, together with the location.</response>
         /// <response code="400">If the configuration value does not pass validation.</response>
         [HttpPost]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ConfigurationContext context, [FromBody] CreateConfigurationValueRequest message)
         {
             if (!ModelState.IsValid)
@@ -86,8 +87,8 @@
         /// <response code="200">If the configuration value is updated, together with the location.</response>
         /// <response code="400">If the configuration value does not pass validation.</response>
         [HttpPut("{id}")]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ConfigurationContext context, [FromRoute] string id, [FromBody] UpdateConfigurationValueRequest message)
         {
             var internalMessage = new UpdateConfigurationValueInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Admin/Events/EventsController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Admin/Events/EventsController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -29,7 +30,7 @@
         /// <summary>Get a list of events.</summary>
         [HttpGet]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder + "," + Roles.Developer)]
-        [ProducesResponseType(typeof(List<EventListItem>), (int) HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context)
         {
             var filtering = Request.ExtractFilteringRequest<EventListItemFilter>();
@@ -49,8 +50,8 @@
         /// <response code="404">If the event cannot be found.</response>
         [HttpGet("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder + "," + Roles.Developer)]
-        [ProducesResponseType(typeof(EventWithData), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] int id)
         {
             var eventData = await context.Events.FirstOrDefaultAsync(x => x.Number == id);

--- a/src/OrganisationRegistry.Api/Backoffice/Admin/Events/Queries/EventListQuery.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Admin/Events/Queries/EventListQuery.cs
@@ -4,6 +4,7 @@ namespace OrganisationRegistry.Api.Backoffice.Admin.Events.Queries
     using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;
+    using System.Runtime.Serialization;
     using Be.Vlaanderen.Basisregisters.Api.Search.Helpers;
     using Be.Vlaanderen.Basisregisters.Converters.Timestamp;
     using Infrastructure.Search;
@@ -15,6 +16,7 @@ namespace OrganisationRegistry.Api.Backoffice.Admin.Events.Queries
     using SqlServer.Event;
     using SqlServer.Infrastructure;
 
+    [DataContract]
     public class EventWithData
     {
         public Guid Id { get; }

--- a/src/OrganisationRegistry.Api/Backoffice/Admin/Projections/ProjectionsController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Admin/Projections/ProjectionsController.cs
@@ -8,6 +8,7 @@ namespace OrganisationRegistry.Api.Backoffice.Admin.Projections
     using System.Threading.Tasks;
     using Infrastructure;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -30,7 +31,7 @@ namespace OrganisationRegistry.Api.Backoffice.Admin.Projections
         /// <summary>Get a list of projections.</summary>
         [HttpGet]
         [OrganisationRegistryAuthorize(Roles = Roles.Developer)]
-        [ProducesResponseType(typeof(List<string>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> Get()
         {
             var projections = typeof(OrganisationRegistrySqlServerAssemblyTokenClass)
@@ -54,7 +55,7 @@ namespace OrganisationRegistry.Api.Backoffice.Admin.Projections
         /// <summary>Get a list of available projection states.</summary>
         [HttpGet("states")]
         [OrganisationRegistryAuthorize(Roles = Roles.Developer)]
-        [ProducesResponseType(typeof(IEnumerable<ProjectionStateItem>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context)
         {
             return Ok(await context.ProjectionStates
@@ -65,7 +66,7 @@ namespace OrganisationRegistry.Api.Backoffice.Admin.Projections
         /// <summary>Get a projection state by its id.</summary>
         [HttpGet("states/{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.Developer)]
-        [ProducesResponseType(typeof(ProjectionStateItem), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, Guid id)
         {
             var state = await context.ProjectionStates
@@ -80,7 +81,7 @@ namespace OrganisationRegistry.Api.Backoffice.Admin.Projections
         /// <summary>Get the max event number.</summary>
         [HttpGet("states/last-event")]
         [OrganisationRegistryAuthorize(Roles = Roles.Developer)]
-        [ProducesResponseType(typeof(int), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> LastEvent([FromServices] OrganisationRegistryContext context)
         {
             return Ok(await context.Events
@@ -90,8 +91,8 @@ namespace OrganisationRegistry.Api.Backoffice.Admin.Projections
 
         [HttpPut("states/{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.Developer)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] OrganisationRegistryContext context, Guid id, [FromBody] UpdateProjectionStateRequest message)
         {
             var state = await context.ProjectionStates

--- a/src/OrganisationRegistry.Api/Backoffice/Admin/Status/StatusController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Admin/Status/StatusController.cs
@@ -8,6 +8,7 @@ namespace OrganisationRegistry.Api.Backoffice.Admin.Status
     using Infrastructure;
     using Infrastructure.Helpers;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Options;
@@ -38,7 +39,7 @@ namespace OrganisationRegistry.Api.Backoffice.Admin.Status
 
         [HttpGet]
         [Route("toggles")]
-        [ProducesResponseType(typeof(TogglesConfiguration), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> GetToggles([FromServices] IOptions<TogglesConfiguration> toggles)
         {
             return Ok(toggles.Value);
@@ -46,7 +47,7 @@ namespace OrganisationRegistry.Api.Backoffice.Admin.Status
 
         [HttpGet]
         [Route("features")]
-        [ProducesResponseType(typeof(TogglesConfiguration), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> GetFeatures([FromServices] IFeatureManager featureManager)
         {
             var features = new Dictionary<string, bool>();

--- a/src/OrganisationRegistry.Api/Backoffice/Admin/Task/TaskController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Admin/Task/TaskController.cs
@@ -8,6 +8,7 @@ namespace OrganisationRegistry.Api.Backoffice.Admin.Task
     using Day.Commands;
     using Infrastructure;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Logging;
@@ -36,8 +37,8 @@ namespace OrganisationRegistry.Api.Backoffice.Admin.Task
         /// <response code="400">If the task information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.AutomatedTask + "," + Roles.Developer)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post(
             [FromServices] Func<Owned<OrganisationRegistryContext>> contextFactory,
             [FromServices] IKboSync kboSync,

--- a/src/OrganisationRegistry.Api/Backoffice/Body/BodyBalancedParticipationController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Body/BodyBalancedParticipationController.cs
@@ -5,6 +5,7 @@ namespace OrganisationRegistry.Api.Backoffice.Body
     using System.Threading.Tasks;
     using Infrastructure;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -28,8 +29,8 @@ namespace OrganisationRegistry.Api.Backoffice.Body
         /// <response code="200">If the body is found.</response>
         /// <response code="404">If the body cannot be found.</response>
         [HttpGet("{id}/balancedparticipation")]
-        [ProducesResponseType(typeof(BodyBalancedParticipationResponse), (int) HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int) HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var body = await context.BodyDetail.FirstOrDefaultAsync(x => x.Id == id);
@@ -44,8 +45,8 @@ namespace OrganisationRegistry.Api.Backoffice.Body
         /// <response code="200">If the body balanced participation info is updated, together with the location.</response>
         /// <response code="400">If the body balanced participation information does not pass validation.</response>
         [HttpPut("{id}/balancedparticipation")]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateBodyBalancedParticipationRequest message)
         {
             var internalMessage = new UpdateBodyBalancedParticipationInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Body/BodyBodyClassificationController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Body/BodyBodyClassificationController.cs
@@ -8,6 +8,7 @@ namespace OrganisationRegistry.Api.Backoffice.Body
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -47,8 +48,8 @@ namespace OrganisationRegistry.Api.Backoffice.Body
         /// <response code="200">If the classification is found.</response>
         /// <response code="404">If the classification cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(BodyBodyClassificationListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid bodyId, [FromRoute] Guid id)
         {
             var body = await context.BodyBodyClassificationList.FirstOrDefaultAsync(x => x.BodyBodyClassificationId == id);
@@ -64,8 +65,8 @@ namespace OrganisationRegistry.Api.Backoffice.Body
         /// <response code="400">If the classification information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid bodyId, [FromBody] AddBodyBodyClassificationRequest message)
         {
             var internalMessage = new AddBodyBodyClassificationInternalRequest(bodyId, message);
@@ -86,8 +87,8 @@ namespace OrganisationRegistry.Api.Backoffice.Body
         /// <response code="400">If the classification information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid bodyId, [FromBody] UpdateBodyBodyClassificationRequest message)
         {
             var internalMessage = new UpdateBodyBodyClassificationInternalRequest(bodyId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Body/BodyContactController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Body/BodyContactController.cs
@@ -8,6 +8,7 @@ namespace OrganisationRegistry.Api.Backoffice.Body
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -47,8 +48,8 @@ namespace OrganisationRegistry.Api.Backoffice.Body
         /// <response code="200">If the contact is found.</response>
         /// <response code="404">If the contact cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(BodyContactListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid bodyId, [FromRoute] Guid id)
         {
             var organisation = await context.BodyContactList.FirstOrDefaultAsync(x => x.BodyContactId == id);
@@ -64,8 +65,8 @@ namespace OrganisationRegistry.Api.Backoffice.Body
         /// <response code="400">If the contact information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid bodyId, [FromBody] AddBodyContactRequest message)
         {
             var internalMessage = new AddBodyContactInternalRequest(bodyId, message);
@@ -86,8 +87,8 @@ namespace OrganisationRegistry.Api.Backoffice.Body
         /// <response code="400">If the contact information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid bodyId, [FromBody] UpdateBodyContactRequest message)
         {
             var internalMessage = new UpdateBodyContactInternalRequest(bodyId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Body/BodyController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Body/BodyController.cs
@@ -10,6 +10,7 @@ namespace OrganisationRegistry.Api.Backoffice.Body
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -32,7 +33,7 @@ namespace OrganisationRegistry.Api.Backoffice.Body
 
         /// <summary>Get a list of available bodies.</summary>
         [HttpGet]
-        [ProducesResponseType(typeof(List<BodyListQueryResult>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context)
         {
             var filtering = Request.ExtractFilteringRequest<BodyListItemFilter>();
@@ -52,8 +53,8 @@ namespace OrganisationRegistry.Api.Backoffice.Body
         /// <response code="200">If the body is found.</response>
         /// <response code="404">If the body cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(BodyResponse), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var body =
@@ -75,8 +76,8 @@ namespace OrganisationRegistry.Api.Backoffice.Body
         /// <response code="400">If the body information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromServices] OrganisationRegistryContext context, [FromBody] RegisterBodyRequest message)
         {
             if (message.OrganisationId.HasValue && !securityService.CanAddBody(User, message.OrganisationId))

--- a/src/OrganisationRegistry.Api/Backoffice/Body/BodyFormalFrameworkController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Body/BodyFormalFrameworkController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -47,8 +48,8 @@
         /// <response code="200">If the formal framework is found.</response>
         /// <response code="404">If the formal framework cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(BodyFormalFrameworkListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid bodyId, [FromRoute] Guid id)
         {
             var bodyFormalFramework = await context.BodyFormalFrameworkList.FirstOrDefaultAsync(x => x.BodyFormalFrameworkId == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the formal framework information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid bodyId, [FromBody] AddBodyFormalFrameworkRequest message)
         {
             var internalMessage = new AddBodyFormalFrameworkInternalRequest(bodyId, message);
@@ -86,8 +87,8 @@
         /// <response code="400">If the formal framework information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid bodyId, [FromBody] UpdateBodyFormalFrameworkRequest message)
         {
             var internalMessage = new UpdateBodyFormalFrameworkInternalRequest(bodyId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Body/BodyInfoController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Body/BodyInfoController.cs
@@ -5,6 +5,7 @@
     using System.Threading.Tasks;
     using Infrastructure;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -27,8 +28,8 @@
         /// <response code="200">If the body is found.</response>
         /// <response code="404">If the body cannot be found.</response>
         [HttpGet("{id}/info")]
-        [ProducesResponseType(typeof(BodyInfoResponse), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var body = await context.BodyDetail.FirstOrDefaultAsync(x => x.Id == id);
@@ -44,8 +45,8 @@
         /// <response code="400">If the body information does not pass validation.</response>
         [HttpPut("{id}/info")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid id, [FromBody] UpdateBodyInfoRequest message)
         {
             var internalMessage = new UpdateBodyInfoInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Body/BodyLifecyclePhaseController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Body/BodyLifecyclePhaseController.cs
@@ -3,11 +3,13 @@
     using System;
     using System.Net;
     using System.Threading.Tasks;
+    using Be.Vlaanderen.Basisregisters.Api;
     using Infrastructure;
     using Infrastructure.Search.Filtering;
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -47,8 +49,8 @@
         /// <response code="200">If the lifecycle phase is found.</response>
         /// <response code="404">If the lifecycle phase cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(BodyLifecyclePhaseListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid bodyId, [FromRoute] Guid id)
         {
             var bodyLifecyclePhase = await context.BodyLifecyclePhaseList.FirstOrDefaultAsync(x => x.BodyLifecyclePhaseId == id);
@@ -64,8 +66,8 @@
         /// <response code="400">If the lifecycle phase information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid bodyId, [FromBody] AddBodyLifecyclePhaseRequest message)
         {
             var internalMessage = new AddBodyLifecyclePhaseInternalRequest(bodyId, message);
@@ -86,8 +88,8 @@
         /// <response code="400">If the lifecycle phase information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid bodyId, [FromBody] UpdateBodyLifecyclePhaseRequest message)
         {
             var internalMessage = new UpdateBodyLifecyclePhaseInternalRequest(bodyId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Body/BodyMandateController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Body/BodyMandateController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Body;
@@ -48,8 +49,8 @@
         /// <response code="200">If the mandate is found.</response>
         /// <response code="404">If the mandate cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(BodyMandateResponse), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid bodyId, [FromRoute] Guid id)
         {
             var bodyMandate = await context.BodyMandateList.FirstOrDefaultAsync(x => x.BodyMandateId == id);
@@ -65,8 +66,8 @@
         /// <response code="400">If the mandate information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid bodyId, [FromBody] AddBodyMandateRequest message)
         {
             var internalMessage = new AddBodyMandateInternalRequest(bodyId, message);
@@ -101,8 +102,8 @@
         /// <response code="400">If the mandate information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid bodyId, [FromBody] UpdateBodyMandateRequest message)
         {
             var internalMessage = new UpdateBodyMandateInternalRequest(bodyId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Body/BodyOrganisationController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Body/BodyOrganisationController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -49,8 +50,8 @@
         /// <response code="200">If the organisation is found.</response>
         /// <response code="404">If the organisation cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(BodyOrganisationListItem), (int) HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int) HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid bodyId, [FromRoute] Guid id)
         {
             var bodyOrganisation =
@@ -67,8 +68,8 @@
         /// <response code="400">If the organisation information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder + "," + Roles.OrgaanBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid bodyId, [FromBody] AddBodyOrganisationRequest message)
         {
             var internalMessage = new AddBodyOrganisationInternalRequest(bodyId, message);
@@ -89,8 +90,8 @@
         /// <response code="400">If the organisation information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder + "," + Roles.OrgaanBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid bodyId, [FromBody] UpdateBodyOrganisationRequest message)
         {
             var internalMessage = new UpdateBodyOrganisationInternalRequest(bodyId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Body/BodySeatController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Body/BodySeatController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -47,8 +48,8 @@
         /// <response code="200">If the seat is found.</response>
         /// <response code="404">If the seat cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(BodySeatListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid bodyId, [FromRoute] Guid id)
         {
             var bodySeat = await context.BodySeatList.FirstOrDefaultAsync(x => x.BodySeatId == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the seat information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid bodyId, [FromBody] AddBodySeatRequest message)
         {
             var internalMessage = new AddBodySeatInternalRequest(bodyId, message);
@@ -86,8 +87,8 @@
         /// <response code="400">If the seat information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid bodyId, [FromBody] UpdateBodySeatRequest message)
         {
             var internalMessage = new UpdateBodySeatInternalRequest(bodyId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Body/BodyValidityController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Body/BodyValidityController.cs
@@ -5,6 +5,7 @@
     using System.Threading.Tasks;
     using Infrastructure;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -27,8 +28,8 @@
         /// <response code="200">If the body is found.</response>
         /// <response code="404">If the body cannot be found.</response>
         [HttpGet("{id}/validity")]
-        [ProducesResponseType(typeof(BodyValidityResponse), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var body = await context.BodyDetail.FirstOrDefaultAsync(x => x.Id == id);
@@ -44,8 +45,8 @@
         /// <response code="400">If the body validity information does not pass validation.</response>
         [HttpPut("{id}/validity")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid id, [FromBody] UpdateBodyValidityRequest message)
         {
             var internalMessage = new UpdateBodyValidityInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Body/Queries/BodyListQuery.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Body/Queries/BodyListQuery.cs
@@ -5,6 +5,7 @@ namespace OrganisationRegistry.Api.Backoffice.Body.Queries
     using System.ComponentModel;
     using System.Linq;
     using System.Linq.Expressions;
+    using System.Runtime.Serialization;
     using Be.Vlaanderen.Basisregisters.Api.Search.Helpers;
     using Infrastructure;
     using Infrastructure.Search;
@@ -13,6 +14,7 @@ namespace OrganisationRegistry.Api.Backoffice.Body.Queries
     using SqlServer.Body;
     using SqlServer.Infrastructure;
 
+    [DataContract]
     public class BodyListQueryResult
     {
         [ExcludeFromCsv]

--- a/src/OrganisationRegistry.Api/Backoffice/Body/Responses/BodyBalancedParticipationResponse.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Body/Responses/BodyBalancedParticipationResponse.cs
@@ -1,8 +1,10 @@
 namespace OrganisationRegistry.Api.Backoffice.Body.Responses
 {
     using System;
+    using System.Runtime.Serialization;
     using SqlServer.Body;
 
+    [DataContract]
     public class BodyBalancedParticipationResponse
     {
         public Guid Id { get; }

--- a/src/OrganisationRegistry.Api/Backoffice/Body/Responses/BodyInfoResponse.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Body/Responses/BodyInfoResponse.cs
@@ -1,8 +1,10 @@
 ﻿namespace OrganisationRegistry.Api.Backoffice.Body.Responses
 {
     using System;
+    using System.Runtime.Serialization;
     using SqlServer.Body;
 
+    [DataContract]
     public class BodyInfoResponse
     {
         public Guid Id { get; }

--- a/src/OrganisationRegistry.Api/Backoffice/Body/Responses/BodyResponse.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Body/Responses/BodyResponse.cs
@@ -1,8 +1,10 @@
 ﻿namespace OrganisationRegistry.Api.Backoffice.Body.Responses
 {
     using System;
+    using System.Runtime.Serialization;
     using SqlServer.Body;
 
+    [DataContract]
     public class BodyResponse
     {
         public Guid Id { get; }

--- a/src/OrganisationRegistry.Api/Backoffice/Body/Responses/BodyValidityResponse.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Body/Responses/BodyValidityResponse.cs
@@ -1,8 +1,10 @@
 namespace OrganisationRegistry.Api.Backoffice.Body.Responses
 {
     using System;
+    using System.Runtime.Serialization;
     using SqlServer.Body;
 
+    [DataContract]
     public class BodyValidityResponse
     {
         public Guid Id { get; }

--- a/src/OrganisationRegistry.Api/Backoffice/Kbo/KboController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Kbo/KboController.cs
@@ -8,6 +8,7 @@ namespace OrganisationRegistry.Api.Backoffice.Kbo
     using Autofac.Features.OwnedInstances;
     using Infrastructure;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Logging;
@@ -35,7 +36,7 @@ namespace OrganisationRegistry.Api.Backoffice.Kbo
         /// <response code="404">If the kbo number does not exist</response>
         [HttpGet("{kboNumberInput}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(NotFoundResult), (int) HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get(
             [FromServices] Func<Owned<OrganisationRegistryContext>> contextFactory,
             [FromServices] IKboOrganisationRetriever kboOrganisationRetriever,

--- a/src/OrganisationRegistry.Api/Backoffice/Kbo/KboRawController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Kbo/KboRawController.cs
@@ -4,6 +4,7 @@ namespace OrganisationRegistry.Api.Backoffice.Kbo
     using System.Threading.Tasks;
     using Infrastructure;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
@@ -36,7 +37,7 @@ namespace OrganisationRegistry.Api.Backoffice.Kbo
         /// <response code="200">The raw request/response from magda kbo lookup.</response>
         [HttpGet("{kboNumberInput}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder + "," + Roles.Developer)]
-        [ProducesResponseType(typeof(NotFoundResult), (int) HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get(
             [FromServices] ISecurityService securityService,
             [FromRoute] string kboNumberInput)

--- a/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationBankAccountController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationBankAccountController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -48,8 +49,8 @@
         /// <response code="200">If the bankAccount is found.</response>
         /// <response code="404">If the bankAccount cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(OrganisationBankAccountListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid organisationId, [FromRoute] Guid id)
         {
             var organisation = await context.OrganisationBankAccountList.FirstOrDefaultAsync(x => x.OrganisationBankAccountId == id);
@@ -64,8 +65,8 @@
         /// <response code="201">If the bankAccount is added, together with the location.</response>
         /// <response code="400">If the bankAccount information does not pass validation.</response>
         [HttpPost]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] AddOrganisationBankAccountRequest message)
         {
             var internalMessage = new AddOrganisationBankAccountInternalRequest(organisationId, message);
@@ -85,8 +86,8 @@
         /// <response code="201">If the bankAccount is updated, together with the location.</response>
         /// <response code="400">If the bankAccount information does not pass validation.</response>
         [HttpPut("{id}")]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] UpdateOrganisationBankAccountRequest message)
         {
             var internalMessage = new UpdateOrganisationBankAccountInternalRequest(organisationId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationBuildingController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationBuildingController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -47,8 +48,8 @@
         /// <response code="200">If the building is found.</response>
         /// <response code="404">If the building cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(OrganisationBuildingListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid organisationId, [FromRoute] Guid id)
         {
             var organisation = await context.OrganisationBuildingList.FirstOrDefaultAsync(x => x.OrganisationBuildingId == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the building information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] AddOrganisationBuildingRequest message)
         {
             var internalMessage = new AddOrganisationBuildingInternalRequest(organisationId, message);
@@ -86,8 +87,8 @@
         /// <response code="400">If the building information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] UpdateOrganisationBuildingRequest message)
         {
             var internalMessage = new UpdateOrganisationBuildingInternalRequest(organisationId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationCapacityController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationCapacityController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -47,8 +48,8 @@
         /// <response code="200">If the capacity is found.</response>
         /// <response code="404">If the capacity cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(OrganisationCapacityResponse), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid organisationId, [FromRoute] Guid id)
         {
             var organisation = await context.OrganisationCapacityList.FirstOrDefaultAsync(x => x.OrganisationCapacityId == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the capacity information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] AddOrganisationCapacityRequest message)
         {
             var internalMessage = new AddOrganisationCapacityInternalRequest(organisationId, message);
@@ -86,8 +87,8 @@
         /// <response code="400">If the capacity information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] UpdateOrganisationCapacityRequest message)
         {
             var internalMessage = new UpdateOrganisationCapacityInternalRequest(organisationId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationContactController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationContactController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -47,8 +48,8 @@
         /// <response code="200">If the contact is found.</response>
         /// <response code="404">If the contact cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(OrganisationContactListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid organisationId, [FromRoute] Guid id)
         {
             var organisation = await context.OrganisationContactList.FirstOrDefaultAsync(x => x.OrganisationContactId == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the contact information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] AddOrganisationContactRequest message)
         {
             var internalMessage = new AddOrganisationContactInternalRequest(organisationId, message);
@@ -86,8 +87,8 @@
         /// <response code="400">If the contact information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] UpdateOrganisationContactRequest message)
         {
             var internalMessage = new UpdateOrganisationContactInternalRequest(organisationId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationController.cs
@@ -9,6 +9,7 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -32,7 +33,7 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
 
         /// <summary>Get a list of available organisations.</summary>
         [HttpGet]
-        [ProducesResponseType(typeof(List<OrganisationListQueryResult>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromServices] ISecurityService securityService)
         {
             var filtering = Request.ExtractFilteringRequest<OrganisationListItemFilter>();
@@ -59,8 +60,8 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
         /// <response code="200">If the organisation is found.</response>
         /// <response code="404">If the organisation cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(OrganisationResponse), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var organisation = await context.OrganisationDetail.FirstOrDefaultAsync(x => x.Id == id);
@@ -76,8 +77,8 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
         /// <response code="400">If the organisation information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post(
             [FromServices] ISecurityService securityService,
             [FromBody] CreateOrganisationRequest message)
@@ -107,8 +108,8 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
         /// <response code="400">If the organisation information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid id, [FromBody] UpdateOrganisationInfoRequest message)
         {
             var internalMessage = new UpdateOrganisationInfoInternalRequest(id, message);
@@ -128,8 +129,8 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
         /// <response code="200">If the organisation is terminated.</response>
         [HttpPut("{id}/terminate")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Delete([FromRoute] Guid id, [FromBody] OrganisationTerminationRequest message)
         {
             await CommandSender.Send(

--- a/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationFormalFrameworkController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationFormalFrameworkController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -47,8 +48,8 @@
         /// <response code="200">If the formal framework is found.</response>
         /// <response code="404">If the formal framework cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(OrganisationFormalFrameworkListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid organisationId, [FromRoute] Guid id)
         {
             var organisation = await context.OrganisationFormalFrameworkList.FirstOrDefaultAsync(x => x.OrganisationFormalFrameworkId == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the formal framework information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] AddOrganisationFormalFrameworkRequest message)
         {
             var internalMessage = new AddOrganisationFormalFrameworkInternalRequest(organisationId, message);
@@ -86,8 +87,8 @@
         /// <response code="400">If the formal framework information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] UpdateOrganisationFormalFrameworkRequest message)
         {
             var internalMessage = new UpdateOrganisationFormalFrameworkInternalRequest(organisationId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationFunctionController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationFunctionController.cs
@@ -8,6 +8,7 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -47,8 +48,8 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
         /// <response code="200">If the function is found.</response>
         /// <response code="404">If the function cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(OrganisationFunctionResponse), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid organisationId, [FromRoute] Guid id)
         {
             var organisation = await context.OrganisationFunctionList.FirstOrDefaultAsync(x => x.OrganisationFunctionId == id);
@@ -64,8 +65,8 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
         /// <response code="400">If the function information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] AddOrganisationFunctionRequest message)
         {
             var internalMessage = new AddOrganisationFunctionInternalRequest(organisationId, message);
@@ -86,8 +87,8 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
         /// <response code="400">If the function information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] UpdateOrganisationFunctionRequest message)
         {
             var internalMessage = new UpdateOrganisationFunctionInternalRequest(organisationId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationKboController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationKboController.cs
@@ -9,6 +9,7 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -31,7 +32,7 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
         /// <response code="200">If the organisation was coupled.</response>
         [HttpPut("{id}/kbo/number/{kboNumber}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder + "," + Roles.Developer)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> CoupleToKboNumber(
             [FromRoute] Guid id,
             [FromRoute] string kboNumber)
@@ -48,7 +49,7 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
         /// <response code="200">If the organisation coupling was cancelled.</response>
         [HttpPut("{id}/kbo/cancel")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder + "," + Roles.Developer)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> CancelCouplingWithKbo([FromRoute] Guid id)
         {
             await CommandSender.Send(
@@ -62,7 +63,7 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
         /// <response code="200">If the organisation was updated.</response>
         [HttpPut("{id}/kbo/sync")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder + "," + Roles.Developer)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> UpdateFromKbo([FromRoute] Guid id)
         {
             await CommandSender.Send(
@@ -78,7 +79,7 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
         /// <response code="200">If the organisation was terminated.</response>
         [HttpPut("{id}/kbo/terminate")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder + "," + Roles.Developer)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> TerminateKboCoupling([FromRoute] Guid id)
         {
             await CommandSender.Send(
@@ -91,7 +92,7 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
         /// <summary>Gets the termination status of an organisation coupled with the KBO.</summary>
         [HttpGet("{id}/kbo/{kboNumber}/termination")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder + "," + Roles.Developer)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> GetTerminationStatus(
             [FromServices] OrganisationRegistryContext context,
             [FromRoute] string kboNumber,
@@ -108,7 +109,7 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
         /// <summary>Get a list of organisations to be terminated according to the KBO.</summary>
         [HttpGet("kbo/terminated")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder + "," + Roles.Developer)]
-        [ProducesResponseType(typeof(List<OrganisationTerminationResponse>), (int) HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context)
         {
             var filtering = Request.ExtractFilteringRequest<OrganisationTerminationListItemFilter>();

--- a/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationKeyController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationKeyController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -47,8 +48,8 @@
         /// <response code="200">If the key is found.</response>
         /// <response code="404">If the key cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(OrganisationKeyListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid organisationId, [FromRoute] Guid id)
         {
             var organisation = await context.OrganisationKeyList.FirstOrDefaultAsync(x => x.OrganisationKeyId == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the key information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] AddOrganisationKeyRequest message)
         {
             var internalMessage = new AddOrganisationKeyInternalRequest(organisationId, message);
@@ -86,8 +87,8 @@
         /// <response code="400">If the key information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] UpdateOrganisationKeyRequest message)
         {
             var internalMessage = new UpdateOrganisationKeyInternalRequest(organisationId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationLabelController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationLabelController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -47,8 +48,8 @@
         /// <response code="200">If the label is found.</response>
         /// <response code="404">If the label cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(OrganisationLabelListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid organisationId, [FromRoute] Guid id)
         {
             var organisation = await context.OrganisationLabelList.FirstOrDefaultAsync(x => x.OrganisationLabelId == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the label information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] AddOrganisationLabelRequest message)
         {
             var internalMessage = new AddOrganisationLabelInternalRequest(organisationId, message);
@@ -86,8 +87,8 @@
         /// <response code="400">If the label information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] UpdateOrganisationLabelRequest message)
         {
             var internalMessage = new UpdateOrganisationLabelInternalRequest(organisationId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationLocationController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationLocationController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -47,8 +48,8 @@
         /// <response code="200">If the location is found.</response>
         /// <response code="404">If the location cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(OrganisationLocationListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid organisationId, [FromRoute] Guid id)
         {
             var organisation = await context.OrganisationLocationList.FirstOrDefaultAsync(x => x.OrganisationLocationId == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the location information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] AddOrganisationLocationRequest message)
         {
             var internalMessage = new AddOrganisationLocationInternalRequest(organisationId, message);
@@ -86,8 +87,8 @@
         /// <response code="400">If the location information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] UpdateOrganisationLocationRequest message)
         {
             var internalMessage = new UpdateOrganisationLocationInternalRequest(organisationId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationOpeningHourController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationOpeningHourController.cs
@@ -8,6 +8,7 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -45,8 +46,8 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
         }
 
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(OrganisationOpeningHourListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get(
             [FromServices] OrganisationRegistryContext context,
             [FromRoute] Guid organisationId,
@@ -61,8 +62,8 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
 
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post(
             [FromServices] ISecurityService securityService,
             [FromRoute] Guid organisationId,
@@ -83,8 +84,8 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
 
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put(
             [FromServices] ISecurityService securityService,
             [FromRoute] Guid organisationId,

--- a/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationOrganisationClassificationController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationOrganisationClassificationController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -47,8 +48,8 @@
         /// <response code="200">If the classification is found.</response>
         /// <response code="404">If the classification cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(OrganisationOrganisationClassificationListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid organisationId, [FromRoute] Guid id)
         {
             var organisation = await context.OrganisationOrganisationClassificationList.FirstOrDefaultAsync(x => x.OrganisationOrganisationClassificationId == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the classification information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] AddOrganisationOrganisationClassificationRequest message)
         {
             var internalMessage = new AddOrganisationOrganisationClassificationInternalRequest(organisationId, message);
@@ -86,8 +87,8 @@
         /// <response code="400">If the classification information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] UpdateOrganisationOrganisationClassificationRequest message)
         {
             var internalMessage = new UpdateOrganisationOrganisationClassificationInternalRequest(organisationId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationParentController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationParentController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -47,8 +48,8 @@
         /// <response code="200">If the parent is found.</response>
         /// <response code="404">If the parent cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(OrganisationParentListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid organisationId, [FromRoute] Guid id)
         {
             var organisation = await context.OrganisationParentList.FirstOrDefaultAsync(x => x.OrganisationOrganisationParentId == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the parent information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] AddOrganisationParentRequest message)
         {
             var internalMessage = new AddOrganisationParentInternalRequest(organisationId, message);
@@ -86,8 +87,8 @@
         /// <response code="400">If the parent information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] UpdateOrganisationParentRequest message)
         {
             var internalMessage = new UpdateOrganisationParentInternalRequest(organisationId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationRegulationController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationRegulationController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.FeatureManagement.Mvc;
@@ -49,8 +50,8 @@
         /// <response code="200">If the regulation is found.</response>
         /// <response code="404">If the regulation cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(OrganisationRegulationListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid organisationId, [FromRoute] Guid id)
         {
             var organisation = await context.OrganisationRegulationList.FirstOrDefaultAsync(x => x.OrganisationRegulationId == id);
@@ -66,8 +67,8 @@
         /// <response code="400">If the regulation information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] AddOrganisationRegulationRequest message)
         {
             var internalMessage = new AddOrganisationRegulationInternalRequest(organisationId, message);
@@ -88,8 +89,8 @@
         /// <response code="400">If the regulation information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] UpdateOrganisationRegulationRequest message)
         {
             var internalMessage = new UpdateOrganisationRegulationInternalRequest(organisationId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationRelationController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Organisation/OrganisationRelationController.cs
@@ -8,6 +8,7 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -47,8 +48,8 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
         /// <response code="200">If the relation is found.</response>
         /// <response code="404">If the relation cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(OrganisationRelationResponse), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid organisationId, [FromRoute] Guid id)
         {
             var organisation = await context.OrganisationRelationList.FirstOrDefaultAsync(x => x.OrganisationRelationId == id);
@@ -64,8 +65,8 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
         /// <response code="400">If the relation information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] AddOrganisationRelationRequest message)
         {
             var internalMessage = new AddOrganisationRelationInternalRequest(organisationId, message);
@@ -86,8 +87,8 @@ namespace OrganisationRegistry.Api.Backoffice.Organisation
         /// <response code="400">If the relation information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromServices] ISecurityService securityService, [FromRoute] Guid organisationId, [FromBody] UpdateOrganisationRelationRequest message)
         {
             var internalMessage = new UpdateOrganisationRelationInternalRequest(organisationId, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/BodyClassification/BodyClassificationController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/BodyClassification/BodyClassificationController.cs
@@ -8,6 +8,7 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.BodyClassification
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Options;
@@ -54,8 +55,8 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.BodyClassification
         /// <response code="200">If the body classification is found.</response>
         /// <response code="404">If the body classification cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(BodyClassificationListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var bodyClassification = await context.BodyClassificationList.FirstOrDefaultAsync(x => x.Id == id);
@@ -71,8 +72,8 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.BodyClassification
         /// <response code="400">If the body classificiation information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreateBodyClassificationRequest message)
         {
             if (!ModelState.IsValid)
@@ -88,8 +89,8 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.BodyClassification
         /// <response code="400">If the body classification information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateBodyClassificationRequest message)
         {
             var internalMessage = new UpdateBodyClassificationInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/BodyClassificationType/BodyClassificationTypeController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/BodyClassificationType/BodyClassificationTypeController.cs
@@ -8,6 +8,7 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.BodyClassificationType
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -47,8 +48,8 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.BodyClassificationType
         /// <response code="200">If the body classification type is found.</response>
         /// <response code="404">If the body classificiation type cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(BodyClassificationTypeListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var key = await context.BodyClassificationTypeList.FirstOrDefaultAsync(x => x.Id == id);
@@ -64,8 +65,8 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.BodyClassificationType
         /// <response code="400">If the body classificiation type information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreateBodyClassificationTypeRequest message)
         {
             if (!ModelState.IsValid)
@@ -81,8 +82,8 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.BodyClassificationType
         /// <response code="400">If the body classification type information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateBodyClassificationTypeRequest message)
         {
             var internalMessage = new UpdateBodyClassificationTypeInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/Building/BuildingController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/Building/BuildingController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -47,8 +48,8 @@
         /// <response code="200">If the building is found.</response>
         /// <response code="404">If the building cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(BuildingListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var building = await context.BuildingList.FirstOrDefaultAsync(x => x.Id == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the building information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreateBuildingRequest message)
         {
             if (!ModelState.IsValid)
@@ -81,8 +82,8 @@
         /// <response code="400">If the building information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateBuildingRequest message)
         {
             var internalMessage = new UpdateBuildingInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/Capacity/CapacityController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/Capacity/CapacityController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -47,8 +48,8 @@
         /// <response code="200">If the capacity is found.</response>
         /// <response code="404">If the capacity cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(CapacityListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var key = await context.CapacityList.FirstOrDefaultAsync(x => x.Id == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the capacity information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreateCapacityRequest message)
         {
             if (!ModelState.IsValid)
@@ -81,8 +82,8 @@
         /// <response code="400">If the capacity information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateCapacityRequest message)
         {
             var internalMessage = new UpdateCapacityInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/ContactType/ContactTypeController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/ContactType/ContactTypeController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -47,8 +48,8 @@
         /// <response code="200">If the contact type is found.</response>
         /// <response code="404">If the contact type cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(ContactTypeListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var key = await context.ContactTypeList.FirstOrDefaultAsync(x => x.Id == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the contact type information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreateContactTypeRequest message)
         {
             if (!ModelState.IsValid)
@@ -81,8 +82,8 @@
         /// <response code="400">If the contact type information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateContactTypeRequest message)
         {
             var internalMessage = new UpdateContactTypeInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/DelegationAssignments/DelegationAssignmentController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/DelegationAssignments/DelegationAssignmentController.cs
@@ -9,6 +9,7 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.DelegationAssignments
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -32,7 +33,7 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.DelegationAssignments
         /// <summary>Get a list of available delegation assignments.</summary>
         [HttpGet("{delegationId}/assignments")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder + "," + Roles.OrganisatieBeheerder)]
-        [ProducesResponseType(typeof(List<DelegationAssignmentListQueryResult>), (int) HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromServices] ISecurityService securityService, [FromRoute] Guid delegationId)
         {
             var delegation = await context.DelegationList.FirstOrDefaultAsync(x => x.Id == delegationId);
@@ -61,8 +62,8 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.DelegationAssignments
         /// <response code="404">If the delegation assignment cannot be found.</response>
         [HttpGet("{delegationId}/assignments/{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder + "," + Roles.OrganisatieBeheerder)]
-        [ProducesResponseType(typeof(DelegationAssignmentListQueryResult), (int) HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int) HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get(
             [FromServices] OrganisationRegistryContext context,
             [FromServices] ISecurityService securityService,
@@ -90,8 +91,8 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.DelegationAssignments
         /// <response code="400">If the delegation assignment information does not pass validation.</response>
         [HttpPost("{delegationId}/assignments")]
         [OrganisationRegistryAuthorize]
-        [ProducesResponseType(typeof(CreatedResult), (int) HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int) HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post(
             [FromServices] OrganisationRegistryContext context,
             [FromServices] ISecurityService securityService,
@@ -122,8 +123,8 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.DelegationAssignments
         /// <response code="400">If the delegation assignment information does not pass validation.</response>
         [HttpPut("{delegationId}/assignments/{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder + "," + Roles.OrganisatieBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int) HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int) HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put(
             [FromServices] OrganisationRegistryContext context,
             [FromServices] ISecurityService securityService,
@@ -155,8 +156,8 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.DelegationAssignments
         /// <response code="400">If the delegation assignment information does not pass validation.</response>
         [HttpDelete("{delegationId}/assignments/{delegationAssignmentId}/{bodyId}/{bodySeatId}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int) HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int) HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Delete(
             [FromServices] OrganisationRegistryContext context,
             [FromServices] ISecurityService securityService,

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/Delegations/DelegationController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/Delegations/DelegationController.cs
@@ -9,6 +9,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Authorization;
@@ -31,7 +32,7 @@
         /// <summary>Get a list of available delegations.</summary>
         [HttpGet]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder + "," + Roles.OrganisatieBeheerder)]
-        [ProducesResponseType(typeof(List<DelegationListQueryResult>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromServices] ISecurityService securityService)
         {
             var filtering = Request.ExtractFilteringRequest<DelegationListItemFilter>();
@@ -58,8 +59,8 @@
         /// <response code="404">If the delegation cannot be found.</response>
         [HttpGet("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder + "," + Roles.OrganisatieBeheerder)]
-        [ProducesResponseType(typeof(DelegationResponse), (int) HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int) HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] ISecurityService securityService, [FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var delegation = await context.DelegationList.FirstOrDefaultAsync(x => x.Id == id);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/Delegations/Responses/DelegationResponse.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/Delegations/Responses/DelegationResponse.cs
@@ -1,8 +1,10 @@
 ﻿namespace OrganisationRegistry.Api.Backoffice.Parameters.Delegations.Responses
 {
     using System;
+    using System.Runtime.Serialization;
     using SqlServer.Delegations;
 
+    [DataContract]
     public class DelegationResponse
     {
         public Guid Id { get; set; }

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/FormalFramework/FormalFrameworkController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/FormalFramework/FormalFrameworkController.cs
@@ -9,6 +9,7 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.FormalFramework
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Options;
@@ -77,8 +78,8 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.FormalFramework
         /// <response code="200">If the formal framework is found.</response>
         /// <response code="404">If the formal framework cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(FormalFrameworkListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var formalFramework = await context.FormalFrameworkList
@@ -96,8 +97,8 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.FormalFramework
         /// <response code="400">If the formal framework information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreateFormalFrameworkRequest message)
         {
             if (!ModelState.IsValid)
@@ -113,8 +114,8 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.FormalFramework
         /// <response code="400">If the formal framework information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateFormalFrameworkRequest message)
         {
             var internalMessage = new UpdateFormalFrameworkInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/FormalFrameworkCategory/FormalFrameworkCategoryController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/FormalFrameworkCategory/FormalFrameworkCategoryController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -47,8 +48,8 @@
         /// <response code="200">If the formal framework category is found.</response>
         /// <response code="404">If the formal framework category cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(FormalFrameworkCategoryListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var formalFrameworkCategory = await context.FormalFrameworkCategoryList.FirstOrDefaultAsync(x => x.Id == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the formal framework category information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreateFormalFrameworkCategoryRequest message)
         {
             if (!ModelState.IsValid)
@@ -81,8 +82,8 @@
         /// <response code="400">If the formal framework category information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateFormalFrameworkCategoryRequest message)
         {
             var internalMessage = new UpdateFormalFrameworkCategoryInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/FunctionType/FunctionTypeController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/FunctionType/FunctionTypeController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -47,8 +48,8 @@
         /// <response code="200">If the function type is found.</response>
         /// <response code="404">If the function type cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(FunctionTypeListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var functionTypeListItem = await context.FunctionTypeList.FirstOrDefaultAsync(x => x.Id == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the function type information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreateFunctionTypeRequest message)
         {
             if (!ModelState.IsValid)
@@ -81,8 +82,8 @@
         /// <response code="400">If the function type information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateFunctionTypeRequest message)
         {
             var internalMessage = new UpdateFunctionTypeInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/KeyType/KeyTypeController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/KeyType/KeyTypeController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -47,8 +48,8 @@
         /// <response code="200">If the key type is found.</response>
         /// <response code="404">If the key type cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(KeyTypeListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var keyType = await context.KeyTypeList.FirstOrDefaultAsync(x => x.Id == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the key type information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreateKeyTypeRequest message)
         {
             if (!ModelState.IsValid)
@@ -81,8 +82,8 @@
         /// <response code="400">If the key type information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateKeyTypeRequest message)
         {
             var internalMessage = new UpdateKeyTypeInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/LabelType/LabelTypeController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/LabelType/LabelTypeController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -50,8 +51,8 @@
         /// <response code="200">If the label type is found.</response>
         /// <response code="404">If the label type cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(LabelTypeListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var key = await context.LabelTypeList.FirstOrDefaultAsync(x => x.Id == id);
@@ -67,8 +68,8 @@
         /// <response code="400">If the label type information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreateLabelTypeRequest message)
         {
             if (!ModelState.IsValid)
@@ -84,8 +85,8 @@
         /// <response code="400">If the label type information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateLabelTypeRequest message)
         {
             var internalMessage = new UpdateLabelTypeInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/LifecyclePhaseType/LifecyclePhaseTypeController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/LifecyclePhaseType/LifecyclePhaseTypeController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -47,8 +48,8 @@
         /// <response code="200">If the lifecyclephase type is found.</response>
         /// <response code="404">If the lifecyclephase type cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(LifecyclePhaseTypeListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var key = await context.LifecyclePhaseTypeList.FirstOrDefaultAsync(x => x.Id == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the lifecyclephase type information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreateLifecyclePhaseTypeRequest message)
         {
             if (!ModelState.IsValid)
@@ -81,8 +82,8 @@
         /// <response code="400">If the lifecyclephase type information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateLifecyclePhaseTypeRequest message)
         {
             var internalMessage = new UpdateLifecyclePhaseTypeInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/Location/LocationController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/Location/LocationController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -47,8 +48,8 @@
         /// <response code="200">If the location type is found.</response>
         /// <response code="404">If the location type cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(LocationResponse), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var location = await context.LocationList.FirstOrDefaultAsync(x => x.Id == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the location information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreateLocationRequest message)
         {
             if (!ModelState.IsValid)
@@ -81,8 +82,8 @@
         /// <response code="400">If the location information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateLocationRequest message)
         {
             var internalMessage = new UpdateLocationInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/LocationType/LocationTypeController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/LocationType/LocationTypeController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -50,8 +51,8 @@
         /// <response code="200">If the location type is found.</response>
         /// <response code="404">If the location type cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(LocationTypeListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var key = await context.LocationTypeList.FirstOrDefaultAsync(x => x.Id == id);
@@ -67,8 +68,8 @@
         /// <response code="400">If the location type information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreateLocationTypeRequest message)
         {
             if (!ModelState.IsValid)
@@ -84,8 +85,8 @@
         /// <response code="400">If the location type information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateLocationTypeRequest message)
         {
             var internalMessage = new UpdateLocationTypeInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/MandateRoleType/MandateRoleTypeController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/MandateRoleType/MandateRoleTypeController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -47,8 +48,8 @@
         /// <response code="200">If the mandate role type is found.</response>
         /// <response code="404">If the mandate role type cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(MandateRoleTypeListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var key = await context.MandateRoleTypeList.FirstOrDefaultAsync(x => x.Id == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the mandate role type information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreateMandateRoleTypeRequest message)
         {
             if (!ModelState.IsValid)
@@ -81,8 +82,8 @@
         /// <response code="400">If the mandate role type information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateMandateRoleTypeRequest message)
         {
             var internalMessage = new UpdateMandateRoleTypeInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/OrganisationClassification/OrganisationClassificationController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/OrganisationClassification/OrganisationClassificationController.cs
@@ -8,6 +8,7 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.OrganisationClassificat
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Options;
@@ -54,8 +55,8 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.OrganisationClassificat
         /// <response code="200">If the organisation classification is found.</response>
         /// <response code="404">If the organisation classification cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(OrganisationClassificationListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var organisationClassification = await context.OrganisationClassificationList.FirstOrDefaultAsync(x => x.Id == id);
@@ -71,8 +72,8 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.OrganisationClassificat
         /// <response code="400">If the organisation classificiation information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreateOrganisationClassificationRequest message)
         {
             if (!ModelState.IsValid)
@@ -88,8 +89,8 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.OrganisationClassificat
         /// <response code="400">If the organisation classification information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateOrganisationClassificationRequest message)
         {
             var internalMessage = new UpdateOrganisationClassificationInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/OrganisationClassificationType/OrganisationClassificationTypeController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/OrganisationClassificationType/OrganisationClassificationTypeController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -50,8 +51,8 @@
         /// <response code="200">If the organisation classification type is found.</response>
         /// <response code="404">If the organisation classificiation type cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(OrganisationClassificationTypeListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var key = await context.OrganisationClassificationTypeList.FirstOrDefaultAsync(x => x.Id == id);
@@ -67,8 +68,8 @@
         /// <response code="400">If the organisation classificiation type information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreateOrganisationClassificationTypeRequest message)
         {
             if (!ModelState.IsValid)
@@ -84,8 +85,8 @@
         /// <response code="400">If the organisation classification type information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateOrganisationClassificationTypeRequest message)
         {
             var internalMessage = new UpdateOrganisationClassificationTypeInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/OrganisationRelationType/OrganisationRelationTypeController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/OrganisationRelationType/OrganisationRelationTypeController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -47,8 +48,8 @@
         /// <response code="200">If the organisation relation type is found.</response>
         /// <response code="404">If the organisation relation type cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(OrganisationRelationTypeListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var key = await context.OrganisationRelationTypeList.FirstOrDefaultAsync(x => x.Id == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the organisation relation type information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreateOrganisationRelationTypeRequest message)
         {
             if (!ModelState.IsValid)
@@ -81,8 +82,8 @@
         /// <response code="400">If the organisation relation type information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateOrganisationRelationTypeRequest message)
         {
             var internalMessage = new UpdateOrganisationRelationTypeInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/Purpose/PurposeController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/Purpose/PurposeController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -47,8 +48,8 @@
         /// <response code="200">If the purpose is found.</response>
         /// <response code="404">If the purpose cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(PurposeListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var key = await context.PurposeList.FirstOrDefaultAsync(x => x.Id == id);
@@ -64,8 +65,8 @@
         /// <response code="400">If the purpose information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreatePurposeRequest message)
         {
             if (!ModelState.IsValid)
@@ -81,8 +82,8 @@
         /// <response code="400">If the purpose information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdatePurposeRequest message)
         {
             var internalMessage = new UpdatePurposeInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/RegulationType/RegulationTypeController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/RegulationType/RegulationTypeController.cs
@@ -8,6 +8,7 @@
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.FeatureManagement.Mvc;
@@ -49,8 +50,8 @@
         /// <response code="200">If the regulation type is found.</response>
         /// <response code="404">If the regulation type cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(RegulationTypeListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var key = await context.RegulationTypeList.FirstOrDefaultAsync(x => x.Id == id);
@@ -66,8 +67,8 @@
         /// <response code="400">If the regulation type information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreateRegulationTypeRequest message)
         {
             if (!ModelState.IsValid)
@@ -83,8 +84,8 @@
         /// <response code="400">If the regulation type information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateRegulationTypeRequest message)
         {
             var internalMessage = new UpdateRegulationTypeInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Parameters/SeatType/SeatTypeController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Parameters/SeatType/SeatTypeController.cs
@@ -8,6 +8,7 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.SeatType
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -47,8 +48,8 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.SeatType
         /// <response code="200">If the seat type is found.</response>
         /// <response code="404">If the seat type cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(SeatTypeListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var key = await context.SeatTypeList.FirstOrDefaultAsync(x => x.Id == id);
@@ -64,8 +65,8 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.SeatType
         /// <response code="400">If the seat type information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreateSeatTypeRequest message)
         {
             if (!ModelState.IsValid)
@@ -81,8 +82,8 @@ namespace OrganisationRegistry.Api.Backoffice.Parameters.SeatType
         /// <response code="400">If the seat type information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdateSeatTypeRequest message)
         {
             var internalMessage = new UpdateSeatTypeInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Person/PersonController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Person/PersonController.cs
@@ -8,6 +8,7 @@ namespace OrganisationRegistry.Api.Backoffice.Person
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
     using Infrastructure.Security;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -47,8 +48,8 @@ namespace OrganisationRegistry.Api.Backoffice.Person
         /// <response code="200">If the person is found.</response>
         /// <response code="404">If the person cannot be found.</response>
         [HttpGet("{id}")]
-        [ProducesResponseType(typeof(PersonListItem), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get([FromServices] OrganisationRegistryContext context, [FromRoute] Guid id)
         {
             var person = await context.PersonList.FirstOrDefaultAsync(x => x.Id == id);
@@ -68,8 +69,8 @@ namespace OrganisationRegistry.Api.Backoffice.Person
         /// <response code="400">If the person information does not pass validation.</response>
         [HttpPost]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Post([FromBody] CreatePersonRequest message)
         {
             if (!ModelState.IsValid)
@@ -85,8 +86,8 @@ namespace OrganisationRegistry.Api.Backoffice.Person
         /// <response code="400">If the person information does not pass validation.</response>
         [HttpPut("{id}")]
         [OrganisationRegistryAuthorize(Roles = Roles.OrganisationRegistryBeheerder)]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Put([FromRoute] Guid id, [FromBody] UpdatePersonRequest message)
         {
             var internalMessage = new UpdatePersonInternalRequest(id, message);

--- a/src/OrganisationRegistry.Api/Backoffice/Report/BodyParticipationReportController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Report/BodyParticipationReportController.cs
@@ -9,6 +9,7 @@ namespace OrganisationRegistry.Api.Backoffice.Report
     using Infrastructure.Search.Filtering;
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using OrganisationRegistry.Infrastructure.Commands;
     using Responses;
@@ -32,9 +33,9 @@ namespace OrganisationRegistry.Api.Backoffice.Report
         /// <param name="bodyId">A body GUID identifier</param>
         /// <returns></returns>
         [HttpGet("bodyparticipation/{bodyId}")]
-        [ProducesResponseType(typeof(IEnumerable<BodyParticipation>), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> GetBodyParticipation(
             [FromServices] OrganisationRegistryContext context,
             [FromServices] IDateTimeProvider dateTimeProvider,
@@ -85,9 +86,9 @@ namespace OrganisationRegistry.Api.Backoffice.Report
         /// <param name="bodyId">A body GUID identifier</param>
         /// <returns></returns>
         [HttpGet("bodyparticipation/{bodyId}/totals")]
-        [ProducesResponseType(typeof(BodyParticipationTotals), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> GetBodyParticipationTotals(
             [FromServices] OrganisationRegistryContext context,
             [FromServices] IDateTimeProvider dateTimeProvider,

--- a/src/OrganisationRegistry.Api/Backoffice/Report/BuildingOrganisationReportController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Report/BuildingOrganisationReportController.cs
@@ -9,6 +9,7 @@ namespace OrganisationRegistry.Api.Backoffice.Report
     using Infrastructure;
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Options;
@@ -42,9 +43,9 @@ namespace OrganisationRegistry.Api.Backoffice.Report
         /// <param name="id">A formal framework GUID identifier</param>
         /// <returns></returns>
         [HttpGet("buildingorganisations/{id}")]
-        [ProducesResponseType(typeof(IEnumerable<BuildingOrganisation>), (int) HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int) HttpStatusCode.NotFound)]
-        [ProducesResponseType(typeof(BadRequestResult), (int) HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> GetBuildingOrganisations(
             [FromServices] Elastic elastic,
             [FromRoute] Guid id)

--- a/src/OrganisationRegistry.Api/Backoffice/Report/CapacityPersonReportController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Report/CapacityPersonReportController.cs
@@ -9,6 +9,7 @@ namespace OrganisationRegistry.Api.Backoffice.Report
     using Infrastructure;
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Options;
@@ -44,9 +45,9 @@ namespace OrganisationRegistry.Api.Backoffice.Report
         /// <param name="id">A capacity GUID identifier</param>
         /// <returns></returns>
         [HttpGet("capacitypersons/{id}")]
-        [ProducesResponseType(typeof(IEnumerable<CapacityPerson>), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> GetCapacityPersons(
             [FromServices] Elastic elastic,
             [FromRoute] Guid id)

--- a/src/OrganisationRegistry.Api/Backoffice/Report/FormalFrameworkBodyReportController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Report/FormalFrameworkBodyReportController.cs
@@ -9,6 +9,7 @@ namespace OrganisationRegistry.Api.Backoffice.Report
     using Infrastructure;
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Options;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -40,9 +41,9 @@ namespace OrganisationRegistry.Api.Backoffice.Report
         /// <param name="id">A formal framework GUID identifier</param>
         /// <returns></returns>
         [HttpGet("formalframeworkbodies/{id}")]
-        [ProducesResponseType(typeof(IEnumerable<FormalFrameworkBody>), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> GetFormalFrameworkBodies(
             [FromServices] Elastic elastic,
             [FromRoute] Guid id)

--- a/src/OrganisationRegistry.Api/Backoffice/Report/FormalFrameworkOrganisationReportController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Report/FormalFrameworkOrganisationReportController.cs
@@ -9,6 +9,7 @@ namespace OrganisationRegistry.Api.Backoffice.Report
     using Infrastructure;
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Options;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -40,9 +41,9 @@ namespace OrganisationRegistry.Api.Backoffice.Report
         /// <param name="id">A formal framework GUID identifier</param>
         /// <returns></returns>
         [HttpGet("formalframeworkorganisations/{id}")]
-        [ProducesResponseType(typeof(IEnumerable<FormalFrameworkOrganisationBase>), (int) HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int) HttpStatusCode.NotFound)]
-        [ProducesResponseType(typeof(BadRequestResult), (int) HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> GetFormalFrameworkOrganisations(
             [FromServices] Elastic elastic,
             [FromServices] IDateTimeProvider dateTimeProvider,
@@ -95,9 +96,9 @@ namespace OrganisationRegistry.Api.Backoffice.Report
         /// <param name="id">A formal framework GUID identifier</param>
         /// <returns></returns>
         [HttpGet("formalframeworkorganisations/{id}/extended")]
-        [ProducesResponseType(typeof(IEnumerable<FormalFrameworkOrganisationExtended>), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> GetFormalFrameworkOrganisationsExtended(
             [FromServices] Elastic elastic,
             [FromServices] IDateTimeProvider dateTimeProvider,
@@ -149,9 +150,9 @@ namespace OrganisationRegistry.Api.Backoffice.Report
         /// <param name="id">A formal framework GUID identifier</param>
         /// <returns></returns>
         [HttpGet("formalframeworkorganisations/vademecum/{id}")]
-        [ProducesResponseType(typeof(IEnumerable<FormalFrameworkOrganisation>), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> GetFormalFrameworkOrganisationsVademecum(
             [FromServices] Elastic elastic,
             [FromRoute] Guid id)

--- a/src/OrganisationRegistry.Api/Backoffice/Report/FormalFrameworkParticipationReportController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Report/FormalFrameworkParticipationReportController.cs
@@ -8,6 +8,7 @@ namespace OrganisationRegistry.Api.Backoffice.Report
     using Infrastructure;
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Options;
     using OrganisationRegistry.Infrastructure.Commands;
@@ -32,9 +33,9 @@ namespace OrganisationRegistry.Api.Backoffice.Report
         /// <param name="formalFrameworkId">A formal framework GUID identifier</param>
         /// <returns></returns>
         [HttpGet("formalframeworkparticipation/{formalFrameworkId}")]
-        [ProducesResponseType(typeof(IEnumerable<FormalFrameworkParticipation>), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> GetFormalFrameworkParticipation(
             [FromServices] OrganisationRegistryContext context,
             [FromRoute] Guid formalFrameworkId)
@@ -81,9 +82,9 @@ namespace OrganisationRegistry.Api.Backoffice.Report
         /// <param name="dateTimeProvider"></param>
         /// <returns></returns>
         [HttpGet("participationsummary")]
-        [ProducesResponseType(typeof(IEnumerable<FormalFrameworkParticipation>), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> GetParticipationSummary(
             [FromServices] OrganisationRegistryContext context,
             [FromServices] IOptions<ApiConfiguration> apiConfiguration,

--- a/src/OrganisationRegistry.Api/Backoffice/Report/OrganisationClassificationReportController.cs
+++ b/src/OrganisationRegistry.Api/Backoffice/Report/OrganisationClassificationReportController.cs
@@ -10,6 +10,7 @@ namespace OrganisationRegistry.Api.Backoffice.Report
     using Infrastructure.Search.Filtering;
     using Infrastructure.Search.Pagination;
     using Infrastructure.Search.Sorting;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Logging;
@@ -48,9 +49,9 @@ namespace OrganisationRegistry.Api.Backoffice.Report
         /// <param name="id"></param>
         /// <returns></returns>
         [HttpGet("classificationorganisations/{id}")]
-        [ProducesResponseType(typeof(IEnumerable<ClassificationOrganisation>), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> GetClassificationOrganisations(
             [FromServices] Elastic elastic,
             [FromRoute] Guid id)
@@ -99,9 +100,9 @@ namespace OrganisationRegistry.Api.Backoffice.Report
         /// <param name="context"></param>
         /// <returns></returns>
         [HttpGet("policydomainclassifications")]
-        [ProducesResponseType(typeof(PagedQueryable<OrganisationClassificationListQueryResult>), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> GetOrganisationClassificationsForPolicyDomain(
             [FromServices] OrganisationRegistryContext context)
         {
@@ -127,9 +128,9 @@ namespace OrganisationRegistry.Api.Backoffice.Report
         /// <param name="context"></param>
         /// <returns></returns>
         [HttpGet("responsibleministerclassifications")]
-        [ProducesResponseType(typeof(PagedQueryable<OrganisationClassificationListQueryResult>), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> GetOrganisationClassificationsForResponsibleMinister(
             [FromServices] OrganisationRegistryContext context)
         {
@@ -157,9 +158,9 @@ namespace OrganisationRegistry.Api.Backoffice.Report
         /// <param name="classificationOrganisationId">A classification organisation GUID identifier</param>
         /// <returns></returns>
         [HttpGet("classificationorganisationsparticipation/{classificationOrganisationId}")]
-        [ProducesResponseType(typeof(IEnumerable<ClassificationOrganisationParticipation>), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(NotFoundResult), (int)HttpStatusCode.NotFound)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> GetClassificationOrganisationParticipation(
             [FromServices] OrganisationRegistryContext context,
             [FromServices] IDateTimeProvider dateTimeProvider,

--- a/src/OrganisationRegistry.Api/Dump/DumpController.cs
+++ b/src/OrganisationRegistry.Api/Dump/DumpController.cs
@@ -14,6 +14,7 @@ namespace OrganisationRegistry.Api.Dump
     using OrganisationRegistry.Infrastructure.Infrastructure.Json;
     using System.Xml;
     using Be.Vlaanderen.Basisregisters.AspNetCore.Mvc.Formatters.Json;
+    using Microsoft.AspNetCore.Http;
     using Newtonsoft.Json.Serialization;
 
     [ApiVersion("1.0")]
@@ -41,7 +42,7 @@ namespace OrganisationRegistry.Api.Dump
         /// <returns></returns>
         [HttpGet("agentschap-zorg-en-gezondheid/full")]
         [HttpGet("agentschap-zorg-en-gezondheid/full.{format}")]
-        [ProducesResponseType(typeof(IEnumerable<OrganisationDump>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> GetOrganisations([FromServices] Elastic elastic)
         {
             var format = _actionContextAccessor.ActionContext.GetValueFromHeader("format")

--- a/src/OrganisationRegistry.Api/Edit/Organisation/OrganisationKeyController.cs
+++ b/src/OrganisationRegistry.Api/Edit/Organisation/OrganisationKeyController.cs
@@ -1,19 +1,27 @@
 ﻿namespace OrganisationRegistry.Api.Edit.Organisation
 {
     using System;
+    using System.Collections.Generic;
     using System.Net;
     using System.Threading.Tasks;
+    using Be.Vlaanderen.Basisregisters.Api.Exceptions;
     using Infrastructure;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.FeatureManagement.Mvc;
     using OrganisationRegistry.Infrastructure.Authorization;
     using OrganisationRegistry.Infrastructure.Commands;
     using Requests;
+    using Swashbuckle.AspNetCore.Annotations;
+    using Swashbuckle.AspNetCore.Filters;
+    using EmptyResult = Infrastructure.EmptyResult;
 
     [FeatureGate(FeatureFlags.EditApi)]
     [ApiVersion("1.0")]
     [AdvertiseApiVersions("1.0")]
     [OrganisationRegistryRoute("edit/organisations/{organisationId:guid}/keys")]
+    [ApiController]
+    [ApiExplorerSettings(GroupName = "Organisatiesleutels")]
     public class OrganisationKeyController : OrganisationRegistryController
     {
         public OrganisationKeyController(ICommandSender commandSender)
@@ -21,12 +29,20 @@
         {
         }
 
-        /// <summary>Create a key for an organisation.</summary>
-        /// <response code="201">If the key is created, together with the location.</response>
-        /// <response code="400">If the key information does not pass validation.</response>
+        /// <summary>Maak een organisatiesleutel aan.</summary>
+        /// <param name="organisationId">Id van de organisatie.</param>
+        /// <response code="201">Als het verzoek aanvaard is.</response>
+        /// <response code="400">Als het verzoek ongeldige data bevat.</response>
+        /// <response code="500">Als er een interne fout is opgetreden.</response>
         [HttpPost]
-        [ProducesResponseType(typeof(CreatedResult), (int)HttpStatusCode.Created)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(EmptyResult), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(BadRequestResponseExamples))]
+        [SwaggerResponseExample(StatusCodes.Status500InternalServerError, typeof(InternalServerErrorResponseExamples))]
+        [Consumes("application/json")]
+        [Produces("application/json")]
         public async Task<IActionResult> Post(
             [FromServices] IEditSecurityService securityService,
             [FromRoute] Guid organisationId,
@@ -47,12 +63,18 @@
             return Created(Url.Action(nameof(Backoffice.Organisation.OrganisationKeyController.Get), new { id = message.OrganisationKeyId }), null);
         }
 
-        /// <summary>Update a key for an organisation.</summary>
-        /// <response code="201">If the key is updated, together with the location.</response>
-        /// <response code="400">If the key information does not pass validation.</response>
+        /// <summary>Pas een organisatiesleutel aan.</summary>
+        /// <param name="organisationId">Id van de organisatie.</param>
+        /// <param name="organisationKeyId">Id van de organisatiesleutel.</param>
+        /// <response code="200">Indien de organisatiesleutel succesvol is aangepast.</response>
+        /// <response code="400">Indien er validatiefouten zijn.</response>
         [HttpPut("{organisationKeyId:guid}")]
-        [ProducesResponseType(typeof(OkResult), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(BadRequestResult), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        [SwaggerResponseExample(StatusCodes.Status200OK, typeof(BadRequestResponseExamples))]
+        [SwaggerResponseExample(StatusCodes.Status400BadRequest, typeof(BadRequestResponseExamples))]
+        [SwaggerResponseExample(StatusCodes.Status500InternalServerError, typeof(InternalServerErrorResponseExamples))]
         public async Task<IActionResult> Put(
             [FromServices] IEditSecurityService securityService,
             [FromRoute] Guid organisationKeyId,

--- a/src/OrganisationRegistry.Api/Edit/Organisation/OrganisationTestAuthController.cs
+++ b/src/OrganisationRegistry.Api/Edit/Organisation/OrganisationTestAuthController.cs
@@ -16,6 +16,8 @@
     [ApiVersion("1.0")]
     [AdvertiseApiVersions("1.0")]
     [OrganisationRegistryRoute("edit")]
+    [ApiController]
+    [ApiExplorerSettings(GroupName = "Test Authenticatie")]
     public class OrganisationTestAuthController : OrganisationRegistryController
     {
         public OrganisationTestAuthController(ICommandSender commandSender)
@@ -23,6 +25,11 @@
         {
         }
 
+        /// <summary>
+        /// Test de authenticatie.
+        /// </summary>
+        /// <remarks>Tijdelijk endpoint bedoeld om de authenticatie te testen.</remarks>
+        /// <returns></returns>
         [HttpGet("auth")]
         [Authorize(AuthenticationSchemes = AuthenticationSchemes.EditApi)]
         public async Task<IActionResult> TestAuthorization()

--- a/src/OrganisationRegistry.Api/Edit/Organisation/Requests/AddOrganisationKeyRequest.cs
+++ b/src/OrganisationRegistry.Api/Edit/Organisation/Requests/AddOrganisationKeyRequest.cs
@@ -6,6 +6,7 @@
     using OrganisationRegistry.Organisation;
     using OrganisationRegistry.Organisation.Commands;
     using SqlServer.Organisation;
+    using Swashbuckle.AspNetCore.Annotations;
 
     public class AddOrganisationKeyInternalRequest
     {
@@ -22,10 +23,27 @@
 
     public class AddOrganisationKeyRequest
     {
+        /// <summary>
+        /// Unieke id van de organisatie sleutel. Wordt gegenereerd indien niet meegegeven.
+        /// </summary>
         public Guid? OrganisationKeyId { get; set; }
+        /// <summary>
+        /// Id van het sleuteltype.
+        /// </summary>
         public Guid KeyTypeId { get; set; }
+        /// <summary>
+        /// Waarde van de sleutel.
+        /// </summary>
         public string KeyValue { get; set; }
+        /// <summary>
+        /// Geldig vanaf.
+        /// </summary>
+        [SwaggerSchema(Format = "date")]
         public DateTime? ValidFrom { get; set; }
+        /// <summary>
+        /// Geldig tot.
+        /// </summary>
+        [SwaggerSchema(Format = "date")]
         public DateTime? ValidTo { get; set; }
     }
 

--- a/src/OrganisationRegistry.Api/Edit/Organisation/Requests/UpdateOrganisationKeyRequest.cs
+++ b/src/OrganisationRegistry.Api/Edit/Organisation/Requests/UpdateOrganisationKeyRequest.cs
@@ -6,6 +6,7 @@
     using OrganisationRegistry.Organisation;
     using OrganisationRegistry.Organisation.Commands;
     using SqlServer.Organisation;
+    using Swashbuckle.AspNetCore.Annotations;
 
     public class UpdateOrganisationKeyInternalRequest
     {
@@ -25,9 +26,23 @@
 
     public class UpdateOrganisationKeyRequest
     {
+        /// <summary>
+        /// Id van het sleuteltype.
+        /// </summary>
         public Guid KeyTypeId { get; set; }
+        /// <summary>
+        /// Waarde van de sleutel.
+        /// </summary>
         public string KeyValue { get; set; }
+        /// <summary>
+        /// Geldig vanaf.
+        /// </summary>
+        [SwaggerSchema(Format = "date")]
         public DateTime? ValidFrom { get; set; }
+        /// <summary>
+        /// Geldig tot.
+        /// </summary>
+        [SwaggerSchema(Format = "date")]
         public DateTime? ValidTo { get; set; }
     }
 

--- a/src/OrganisationRegistry.Api/Infrastructure/EmptyResult.cs
+++ b/src/OrganisationRegistry.Api/Infrastructure/EmptyResult.cs
@@ -1,0 +1,7 @@
+namespace OrganisationRegistry.Api.Infrastructure
+{
+    public class EmptyResult
+    {
+
+    }
+}

--- a/src/OrganisationRegistry.Api/Infrastructure/Startup.cs
+++ b/src/OrganisationRegistry.Api/Infrastructure/Startup.cs
@@ -121,6 +121,13 @@ namespace OrganisationRegistry.Api.Infrastructure
                         },
                         Swagger =
                         {
+                            MiddlewareHooks =
+                            {
+                                AfterSwaggerGen = x =>
+                                {
+                                    x.EnableAnnotations();
+                                }
+                            },
                             ApiInfo = (provider, description) => new OpenApiInfo
                             {
                                 Version = description.ApiVersion.ToString(),
@@ -133,7 +140,10 @@ namespace OrganisationRegistry.Api.Infrastructure
                                     Url = new Uri("https://legacy.basisregisters.vlaanderen")
                                 }
                             },
-                            XmlCommentPaths = new[] {typeof(Startup).GetTypeInfo().Assembly.GetName().Name}
+                            XmlCommentPaths = new[]
+                            {
+                                typeof(Startup).GetTypeInfo().Assembly.GetName().Name,
+                            }!
                         },
                         Server =
                         {
@@ -148,7 +158,12 @@ namespace OrganisationRegistry.Api.Infrastructure
                                 cfg.FormatterMappings.SetMediaTypeMappingForFormat("csv", MediaTypeHeaderValue.Parse("text/csv"));
                                 cfg.EnableEndpointRouting = false;
                             },
-                            AfterMvc = builder => builder.AddFormatterMappings(),
+                            AfterMvc = builder => builder
+                                .AddFormatterMappings()
+                                .ConfigureApiBehaviorOptions(options =>
+                                {
+                                    options.SuppressModelStateInvalidFilter = true;
+                                }),
                             AfterHealthChecks = health =>
                             {
                                 var connectionStrings = _configuration
@@ -164,7 +179,7 @@ namespace OrganisationRegistry.Api.Infrastructure
                                 health.AddDbContextCheck<OrganisationRegistryContext>(
                                     $"dbcontext-{nameof(OrganisationRegistryContext).ToLowerInvariant()}",
                                     tags: new[] {DatabaseTag, "sql", "sqlserver"});
-                            }
+                            },
                         }
                     });
 
@@ -245,7 +260,7 @@ namespace OrganisationRegistry.Api.Infrastructure
                             .UseOrganisationRegistryEventSourcing()
                             //.UseOrganisationRegistryCookieAuthentication(tokenValidationParameters)
                             //.UseOrganisationRegistryJwtBearerAuthentication(tokenValidationParameters)
-                            .UseAuthentication()
+                            .UseAuthentication(),
                     }
                 });
         }

--- a/src/OrganisationRegistry.Api/Infrastructure/WegwijsController.cs
+++ b/src/OrganisationRegistry.Api/Infrastructure/WegwijsController.cs
@@ -1,5 +1,6 @@
 ﻿namespace OrganisationRegistry.Api.Infrastructure
 {
+    using Be.Vlaanderen.Basisregisters.Api;
     using Microsoft.AspNetCore.Mvc;
     using OrganisationRegistry.Infrastructure.Commands;
 

--- a/src/OrganisationRegistry.Api/Infrastructure/WegwijsRouteAttribute.cs
+++ b/src/OrganisationRegistry.Api/Infrastructure/WegwijsRouteAttribute.cs
@@ -1,13 +1,10 @@
 namespace OrganisationRegistry.Api.Infrastructure
 {
-    using Microsoft.AspNetCore.Mvc;
+    using Be.Vlaanderen.Basisregisters.Api;
 
-    public class OrganisationRegistryRouteAttribute : RouteAttribute
+    public class OrganisationRegistryRouteAttribute : ApiRouteAttribute
     {
-        //private const string Prefix = "";
-        private const string Prefix = "v{version:apiVersion}/";
-
-        public OrganisationRegistryRouteAttribute(string template) : base(Prefix + template)
+        public OrganisationRegistryRouteAttribute(string template) : base(template)
         {
         }
     }

--- a/src/OrganisationRegistry.Api/Search/SearchController.cs
+++ b/src/OrganisationRegistry.Api/Search/SearchController.cs
@@ -25,6 +25,7 @@ namespace OrganisationRegistry.Api.Search
     using OrganisationRegistry.Infrastructure.Infrastructure.Json;
     using Be.Vlaanderen.Basisregisters.Api.Search.Helpers;
     using ElasticSearch;
+    using Microsoft.AspNetCore.Http;
 
     [ApiVersion("1.0")]
     [AdvertiseApiVersions("1.0")]
@@ -60,7 +61,7 @@ namespace OrganisationRegistry.Api.Search
         /// <param name="sort">Elasticsearch sorting.</param>
         /// <param name="scroll">Enable Elasticsearch scrolling.</param>
         [HttpGet("{indexName}")]
-        [ProducesResponseType(typeof(IEnumerable<OrganisationDocument>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> GetApiSearch(
             string indexName,
             [FromServices] Elastic elastic,
@@ -113,7 +114,7 @@ namespace OrganisationRegistry.Api.Search
         /// <param name="sort">Elasticsearch sorting.</param>
         /// <param name="scroll">Enable Elasticsearch scrolling.</param>
         [HttpGet("box/{indexName}")]
-        [ProducesResponseType(typeof(IEnumerable<OrganisationDocument>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> GetSearch(
             string indexName,
             [FromServices] Elastic elastic,
@@ -228,7 +229,7 @@ namespace OrganisationRegistry.Api.Search
 
         /// <summary>Search all organisations.</summary>
         [HttpPost("{indexName}")]
-        [ProducesResponseType(typeof(IEnumerable<OrganisationDocument>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> PostApiSearch(
             string indexName,
             [FromServices] Elastic elastic,
@@ -276,7 +277,7 @@ namespace OrganisationRegistry.Api.Search
         /// <param name="elastic"></param>
         /// <param name="id">Elasticsearch scroll id.</param>
         [HttpGet("{indexName}/scroll")]
-        [ProducesResponseType(typeof(IEnumerable<OrganisationDocument>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> ScrollApiSearch(
             string indexName,
             [FromServices] Elastic elastic,

--- a/src/OrganisationRegistry.Infrastructure/Configuration/TogglesConfiguration.cs
+++ b/src/OrganisationRegistry.Infrastructure/Configuration/TogglesConfiguration.cs
@@ -1,9 +1,11 @@
 namespace OrganisationRegistry.Infrastructure.Configuration
 {
     using System;
+    using System.Runtime.Serialization;
     using Be.Vlaanderen.Basisregisters.Converters.Timestamp;
     using Newtonsoft.Json;
 
+    [DataContract]
     public class TogglesConfiguration
     {
         public static string Section = "Toggles";

--- a/src/OrganisationRegistry.SqlServer/Body/BodyBodyClassificationListItemView.cs
+++ b/src/OrganisationRegistry.SqlServer/Body/BodyBodyClassificationListItemView.cs
@@ -9,6 +9,7 @@ namespace OrganisationRegistry.SqlServer.Body
     using System;
     using System.Data.Common;
     using System.Linq;
+    using System.Runtime.Serialization;
     using System.Threading.Tasks;
     using OrganisationRegistry.Body.Events;
     using OrganisationRegistry.BodyClassification.Events;
@@ -16,6 +17,7 @@ namespace OrganisationRegistry.SqlServer.Body
     using OrganisationRegistry.Infrastructure;
     using OrganisationRegistry.Infrastructure.Events;
 
+    [DataContract]
     public class BodyBodyClassificationListItem
     {
         public Guid BodyBodyClassificationId { get; set; }

--- a/src/OrganisationRegistry.SqlServer/Body/BodyContactListItemView.cs
+++ b/src/OrganisationRegistry.SqlServer/Body/BodyContactListItemView.cs
@@ -8,12 +8,14 @@ namespace OrganisationRegistry.SqlServer.Body
     using OrganisationRegistry.Infrastructure.Events;
     using OrganisationRegistry.Body.Events;
     using System.Linq;
+    using System.Runtime.Serialization;
     using System.Threading.Tasks;
     using ContactType;
     using Microsoft.Extensions.Logging;
     using OrganisationRegistry.ContactType.Events;
     using OrganisationRegistry.Infrastructure;
 
+    [DataContract]
     public class BodyContactListItem
     {
         public Guid BodyContactId { get; set; }

--- a/src/OrganisationRegistry.SqlServer/Body/BodyFormalFrameworkListItemView.cs
+++ b/src/OrganisationRegistry.SqlServer/Body/BodyFormalFrameworkListItemView.cs
@@ -9,12 +9,14 @@
     using OrganisationRegistry.Body.Events;
 
     using System.Linq;
+    using System.Runtime.Serialization;
     using System.Threading.Tasks;
     using FormalFramework;
     using Microsoft.Extensions.Logging;
     using OrganisationRegistry.FormalFramework.Events;
     using OrganisationRegistry.Infrastructure;
 
+    [DataContract]
     public class BodyFormalFrameworkListItem
     {
         public Guid BodyFormalFrameworkId { get; set; }

--- a/src/OrganisationRegistry.SqlServer/Event/EventList.cs
+++ b/src/OrganisationRegistry.SqlServer/Event/EventList.cs
@@ -1,12 +1,14 @@
 namespace OrganisationRegistry.SqlServer.Event
 {
     using System;
+    using System.Runtime.Serialization;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.EntityFrameworkCore.Metadata.Builders;
     using Infrastructure;
     using OrganisationRegistry.Infrastructure;
     using OrganisationRegistry.Infrastructure.EventStore;
 
+    [DataContract]
     public class EventListItem
     {
         public Guid Id { get; set; }

--- a/src/OrganisationRegistry.SqlServer/ProjectionState/ProjectionStateList.cs
+++ b/src/OrganisationRegistry.SqlServer/ProjectionState/ProjectionStateList.cs
@@ -1,11 +1,13 @@
 ﻿namespace OrganisationRegistry.SqlServer.ProjectionState
 {
     using System;
+    using System.Runtime.Serialization;
     using Infrastructure;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.EntityFrameworkCore.Metadata.Builders;
     using OrganisationRegistry.Infrastructure;
 
+    [DataContract]
     public class ProjectionStateItem
     {
         public Guid Id { get; set; }

--- a/src/OrganisationRegistry.UI/Infrastructure/Startup.cs
+++ b/src/OrganisationRegistry.UI/Infrastructure/Startup.cs
@@ -75,8 +75,6 @@ namespace OrganisationRegistry.UI.Infrastructure
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
-            //loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-
             // TODO: redirect index.html to / (and remove from web.config)
 
             app.Use(async (context, next) =>
@@ -103,8 +101,6 @@ namespace OrganisationRegistry.UI.Infrastructure
             app.UseResponseCompression();
             app.UseDefaultFiles();
             app.UseStaticFiles();
-
-            //app.UseSwaggerUi("docs", $"{Configuration["Api:Endpoint"]}/docs/v1/docs.json");
 
             if (env.IsDevelopment())
                 app.UseDeveloperExceptionPage();


### PR DESCRIPTION
Swagger docs now work again, but only for the edit api. This is the only
documentation we need right now. Work still needs to happen on providing
more correct and extensive documentation and examples.