### PR TITLE
feat: or-740 migration to fix nullable isActive column

### DIFF
--- a/src/OrganisationRegistry.SqlServer/Migrations/20220302084933_AlterTable_OrganisationCapacityList_Set_IsActive_NotNull.Designer.cs
+++ b/src/OrganisationRegistry.SqlServer/Migrations/20220302084933_AlterTable_OrganisationCapacityList_Set_IsActive_NotNull.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OrganisationRegistry.SqlServer.Infrastructure;
 
 namespace OrganisationRegistry.SqlServer.Migrations
 {
     [DbContext(typeof(OrganisationRegistryContext))]
-    partial class OrganisationRegistryContextModelSnapshot : ModelSnapshot
+    [Migration("20220302084933_AlterTable_OrganisationCapacityList_Set_IsActive_NotNull")]
+    partial class AlterTable_OrganisationCapacityList_Set_IsActive_NotNull
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OrganisationRegistry.SqlServer/Migrations/20220302084933_AlterTable_OrganisationCapacityList_Set_IsActive_NotNull.cs
+++ b/src/OrganisationRegistry.SqlServer/Migrations/20220302084933_AlterTable_OrganisationCapacityList_Set_IsActive_NotNull.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace OrganisationRegistry.SqlServer.Migrations
+{
+    public partial class AlterTable_OrganisationCapacityList_Set_IsActive_NotNull : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+UPDATE [Backoffice].[OrganisationCapacityList]
+SET IsActive = 0
+WHERE IsActive IS null
+");
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsActive",
+                schema: "Backoffice",
+                table: "OrganisationCapacityList",
+                type: "bit",
+                nullable: false,
+                defaultValue: false,
+                oldClrType: typeof(bool),
+                oldType: "bit",
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsActive",
+                schema: "Backoffice",
+                table: "OrganisationCapacityList",
+                type: "bit",
+                nullable: true,
+                oldClrType: typeof(bool),
+                oldType: "bit");
+        }
+    }
+}


### PR DESCRIPTION
We moeten wel eens kijken naar van waar de migration runner zijn connectionstring haalt ... heb dat voor nu overruled in de OnConfiguring in de DbContext ...