### PR TITLE
chore: or-958 reduce warnings for OSC projects

### DIFF
--- a/src/OpenSearch.Net/OpenSearch.Net.csproj
+++ b/src/OpenSearch.Net/OpenSearch.Net.csproj
@@ -11,20 +11,24 @@
     <TargetFramework>net6.0</TargetFramework>
     <DefineConstants>$(DefineConstants);DOTNETCORE</DefineConstants>
   </PropertyGroup>
-  
+
+  <PropertyGroup>
+    <NoWarn>8618,1591</NoWarn>
+  </PropertyGroup>
+
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    
+
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    
+
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
-      
+
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>
@@ -38,7 +42,7 @@
     <InternalsVisibleTo Include="OpenSearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateOriginal" Key="$(ExposedPublicKey)" />
     <InternalsVisibleTo Include="OpenSearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateCamelCase" Key="$(ExposedPublicKey)" />
     <InternalsVisibleTo Include="OpenSearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateSnakeCase" Key="$(ExposedPublicKey)" />
-    
+
     <InternalsVisibleTo Include="Tests" Key="$(ExposedPublicKey)" />
 
   </ItemGroup>

--- a/src/Osc/Osc.csproj
+++ b/src/Osc/Osc.csproj
@@ -5,13 +5,17 @@
     <Title>OSC - OpenSearch .NET high level client</Title>
     <PackageTags>opensearch;opensearch;search;lucene;osc</PackageTags>
     <Description>
-      Strongly typed interface to OpenSearch. Fluent and classic object initializer mappings of requests and 
+      Strongly typed interface to OpenSearch. Fluent and classic object initializer mappings of requests and
       responses. Uses and exposes OpenSearch.Net.
     </Description>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
   </PropertyGroup>
-  
+
+  <PropertyGroup>
+    <NoWarn>8618,1591</NoWarn>
+  </PropertyGroup>
+
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Since these projects are copied from github, it makes less sense for us
to receive warnings like these.