### PR TITLE
fix: or-1013 handle single role

### DIFF
--- a/src/OrganisationRegistry.Vue2/src/stores/userTokenResult.js
+++ b/src/OrganisationRegistry.Vue2/src/stores/userTokenResult.js
@@ -9,9 +9,9 @@ export class UserTokenResult {
         name: decodedJwtToken.family_name,
         firstName: decodedJwtToken.given_name,
         roles: decodedJwtToken.role,
-        translatedRoles: decodedJwtToken.role.map((x) =>
-          UserTokenResult.#translateRole(x)
-        ),
+        translatedRoles: []
+          .concat(decodedJwtToken.role)
+          .map((x) => UserTokenResult.#translateRole(x)),
       };
     }
   }
@@ -49,6 +49,7 @@ export class UserTokenResult {
     try {
       return new UserTokenResult(jwtDecode(jwt), true);
     } catch (e) {
+      console.error(e);
       return new UserTokenResult(null, false);
     }
   }


### PR DESCRIPTION
When there's only a single role for the user, the server sends back a
single string instead of an array of strings. This fix allows handling
both cases.