### PR TITLE
fix: update Traefik ingress host rules for k3d Tilt demo

### DIFF
--- a/demo/k8s/ingress.yaml
+++ b/demo/k8s/ingress.yaml
@@ -19,7 +19,7 @@ spec:
   entryPoints:
     - web
   routes:
-  - match: HostRegexp(`{h:keycloak\..+}`)
+  - match: HostRegexp(`^keycloak\..+$`)
     kind: Rule
     services:
     - name: keycloak
@@ -34,7 +34,7 @@ spec:
   entryPoints:
     - web
   routes:
-  - match: HostRegexp(`{h:api\..+}`)
+  - match: HostRegexp(`^api\..+$`)
     kind: Rule
     services:
     - name: api
@@ -49,7 +49,7 @@ spec:
   entryPoints:
     - web
   routes:
-  - match: HostRegexp(`{h:ui\..+}`)
+  - match: HostRegexp(`^ui\..+$`)
     kind: Rule
     services:
     - name: ui
@@ -64,7 +64,7 @@ spec:
   entryPoints:
     - web
   routes:
-  - match: HostRegexp(`{h:app\..+}`)
+  - match: HostRegexp(`^app\..+$`)
     kind: Rule
     services:
     - name: nuxt-bff
@@ -79,7 +79,7 @@ spec:
   entryPoints:
     - web
   routes:
-  - match: HostRegexp(`{h:m2m\..+}`)
+  - match: HostRegexp(`^m2m\..+$`)
     kind: Rule
     services:
     - name: m2m-demo
@@ -94,7 +94,7 @@ spec:
   entryPoints:
     - web
   routes:
-  - match: HostRegexp(`{h:seq\..+}`)
+  - match: HostRegexp(`^seq\..+$`)
     kind: Rule
     services:
     - name: seq


### PR DESCRIPTION
Deze PR maakt de k3d/Tilt demo opnieuw bereikbaar via de verwachte *.localhost:9080 hosts. De oorzaak was dat de Traefik IngressRoute configuratie in demo/k8s/ingress.yaml nog oude HostRegexp-syntax gebruikte die niet meer correct werkte met Traefik v3. Daardoor kwamen requests wel bij Traefik aan, maar eindigden ze op 404 page not found.

In deze wijziging zijn de hostregels aangepast naar Traefik v3-compatibele regexpatronen voor keycloak, api, ui, app, m2m en seq. Daarna is de volledige demo opnieuw gevalideerd op k3d met Tilt. De relevante endpoints antwoorden opnieuw correct via keycloak.localhost:9080, api.localhost:9080, ui.localhost:9080, m2m.localhost:9080 en app.localhost:9080.

Als je ook een iets formelere PR-beschrijving wilt met secties zoals Probleem, Oplossing en Validatie, gebruik deze versie:

Probleem
De lokale k3d/Tilt demo was gedeployed, maar de publieke hostnamen achter Traefik gaven 404 terug. De IngressRoute-configuratie gebruikte nog HostRegexp-syntax die niet meer overeenkomt met Traefik v3.

Oplossing
De host matching in demo/k8s/ingress.yaml is aangepast naar Traefik v3-compatibele regexregels voor alle demo-services:

keycloak
api
ui
app
m2m
seq